### PR TITLE
feat(database): add CloudNativePG operator and reusable cluster component

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/app/helmrelease.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/app/helmrelease.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: cloudnative-pg
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.27.1
+  url: oci://ghcr.io/cloudnative-pg/charts/cloudnative-pg
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: cloudnative-pg
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: cloudnative-pg
+  values:
+    crds:
+      create: true
+    monitoring:
+      podMonitorEnabled: true
+      grafanaDashboard:
+        create: true

--- a/kubernetes/apps/database/cloudnative-pg/app/kustomization.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/app/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/apps/database/cloudnative-pg/barman-cloud/helmrelease.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/barman-cloud/helmrelease.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: barman-cloud
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.5.0
+  url: oci://ghcr.io/cloudnative-pg/charts/plugin-barman-cloud
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: barman-cloud
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: barman-cloud
+  values:
+    crds:
+      enabled: true
+    cert-manager:
+      enabled: false

--- a/kubernetes/apps/database/cloudnative-pg/barman-cloud/kustomization.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/barman-cloud/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/apps/database/cloudnative-pg/ks.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/ks.yaml
@@ -1,0 +1,51 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app cloudnative-pg
+  namespace: &namespace database
+spec:
+  dependsOn:
+    - name: cert-manager
+      namespace: cert-manager
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: cloudnative-pg
+      namespace: *namespace
+  interval: 1h
+  path: ./kubernetes/apps/database/cloudnative-pg/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cloudnative-pg-barman-cloud
+  namespace: &namespace database
+spec:
+  dependsOn:
+    - name: cloudnative-pg
+      namespace: *namespace
+    - name: cert-manager
+      namespace: cert-manager
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: barman-cloud
+      namespace: *namespace
+    - apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      name: objectstores.barmancloud.cnpg.io
+  interval: 1h
+  path: ./kubernetes/apps/database/cloudnative-pg/barman-cloud
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace

--- a/kubernetes/apps/database/kustomization.yaml
+++ b/kubernetes/apps/database/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: database
+components:
+  - ../../components/common
+resources:
+  - ./cloudnative-pg/ks.yaml

--- a/kubernetes/components/cnpg-cluster/cluster.yaml
+++ b/kubernetes/components/cnpg-cluster/cluster.yaml
@@ -1,0 +1,48 @@
+---
+# yaml-language-server: $schema=https://github.com/datreeio/CRDs-catalog/raw/refs/heads/main/postgresql.cnpg.io/cluster_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: "${APP}-pg"
+  annotations:
+    cnpg.io/skipEmptyWalArchiveCheck: "enabled"
+spec:
+  instances: ${CNPG_INSTANCES:=1}
+  imageCatalogRef:
+    apiGroup: postgresql.cnpg.io
+    kind: ClusterImageCatalog
+    major: ${CNPG_PG_MAJOR:=17}
+    name: postgresql
+  enableSuperuserAccess: true
+  superuserSecret:
+    name: "${APP}-pg-superuser"
+  storage:
+    size: "${CNPG_CAPACITY:=5Gi}"
+    storageClass: "${CNPG_STORAGECLASS:=ceph-block}"
+  resources:
+    limits:
+      memory: "${CNPG_MEMORY_LIMIT:=256Mi}"
+    requests:
+      cpu: "${CNPG_CPU_REQUEST:=50m}"
+  # For first deploy (no backup exists yet), temporarily change to:
+  #   bootstrap:
+  #     initdb:
+  #       database: app
+  #       owner: app
+  # After the first ScheduledBackup completes, switch back to recovery.
+  bootstrap:
+    recovery:
+      source: "${APP}-pg-v1"
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: "${APP}-pg-backup"
+        serverName: "${APP}-pg-v1"
+  externalClusters:
+    - name: "${APP}-pg-v1"
+      plugin:
+        name: barman-cloud.cloudnative-pg.io
+        parameters:
+          barmanObjectName: "${APP}-pg-backup"
+          serverName: "${APP}-pg-v1"

--- a/kubernetes/components/cnpg-cluster/externalsecret.yaml
+++ b/kubernetes/components/cnpg-cluster/externalsecret.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: "${APP}-cnpg"
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: bitwarden-secretsmanager
+  target:
+    name: "${APP}-cnpg-secret"
+    template:
+      data:
+        AWS_REGION: garage
+        AWS_ACCESS_KEY_ID: "{{ .GARAGE_ACCESS_KEY_ID }}"
+        AWS_SECRET_ACCESS_KEY: "{{ .GARAGE_SECRET_ACCESS_KEY }}"
+  data:
+    - secretKey: GARAGE_ACCESS_KEY_ID
+      remoteRef:
+        key: "98ff717f-76c7-4bba-8f96-b3fa0075db66"
+    - secretKey: GARAGE_SECRET_ACCESS_KEY
+      remoteRef:
+        key: "7917e6a9-f031-4ce6-95c9-b3fa0075f3c7"

--- a/kubernetes/components/cnpg-cluster/kustomization.yaml
+++ b/kubernetes/components/cnpg-cluster/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - ./cluster.yaml
+  - ./externalsecret.yaml
+  - ./objectstore.yaml
+  - ./scheduledbackup.yaml

--- a/kubernetes/components/cnpg-cluster/objectstore.yaml
+++ b/kubernetes/components/cnpg-cluster/objectstore.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: "${APP}-pg-backup"
+spec:
+  retentionPolicy: "${CNPG_RETENTION:=15d}"
+  configuration:
+    destinationPath: "s3://cnpg/${APP}/"
+    endpointURL: "http://snotra.internal:3900"
+    s3Credentials:
+      region:
+        name: "${APP}-cnpg-secret"
+        key: AWS_REGION
+      accessKeyId:
+        name: "${APP}-cnpg-secret"
+        key: AWS_ACCESS_KEY_ID
+      secretAccessKey:
+        name: "${APP}-cnpg-secret"
+        key: AWS_SECRET_ACCESS_KEY
+  instanceSidecarConfiguration:
+    env:
+      - name: AWS_REQUEST_CHECKSUM_CALCULATION
+        value: when_required
+      - name: AWS_RESPONSE_CHECKSUM_VALIDATION
+        value: when_required

--- a/kubernetes/components/cnpg-cluster/scheduledbackup.yaml
+++ b/kubernetes/components/cnpg-cluster/scheduledbackup.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: "${APP}-pg"
+spec:
+  backupOwnerReference: self
+  cluster:
+    name: "${APP}-pg"
+  schedule: "0 0 2 * * *"
+  immediate: true
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io


### PR DESCRIPTION
## Summary
- Deploys CloudNativePG operator and Barman Cloud plugin to the `database` namespace
- Adds a reusable Kustomize component (`components/cnpg-cluster/`) for per-app PostgreSQL clusters with backup to Garage (S3-compatible) on the NAS
- Component provides: CNPG Cluster CR, Barman ObjectStore, ScheduledBackup, and ExternalSecret for S3 credentials

## Prerequisites before merging
- [x] Garage running on Unraid NAS (Docker Compose, port 3900)
- [x] Garage bucket `cnpg` and access key created
- [x] Credentials stored in Bitwarden Secrets Manager
- [x] OPNsense firewall rule: Cluster VLAN → Unraid VLAN TCP 3900

## Usage
Apps reference the component in their `ks.yaml`:
```yaml
spec:
  components:
    - ../../../../components/cnpg-cluster
  dependsOn:
    - name: cloudnative-pg-barman-cloud
      namespace: database
  postBuild:
    substitute:
      APP: myapp
```

## Test plan
- [ ] Verify CNPG operator and barman-cloud plugin deploy successfully to `database` namespace
- [ ] Verify no clusters are created until an app references the component
- [ ] Verify ExternalSecret syncs Garage credentials from Bitwarden

🤖 Generated with [Claude Code](https://claude.com/claude-code)