### PR TITLE
fix(auth): use direct imageName instead of ClusterImageCatalog

### DIFF
--- a/kubernetes/apps/auth/authelia/db/cluster.yaml
+++ b/kubernetes/apps/auth/authelia/db/cluster.yaml
@@ -8,11 +8,7 @@ metadata:
     cnpg.io/skipEmptyWalArchiveCheck: "enabled"
 spec:
   instances: 1
-  imageCatalogRef:
-    apiGroup: postgresql.cnpg.io
-    kind: ClusterImageCatalog
-    major: 17
-    name: postgresql
+  imageName: ghcr.io/cloudnative-pg/postgresql:17
   enableSuperuserAccess: true
   superuserSecret:
     name: authelia-pg-superuser

--- a/kubernetes/apps/auth/lldap/db/cluster.yaml
+++ b/kubernetes/apps/auth/lldap/db/cluster.yaml
@@ -8,11 +8,7 @@ metadata:
     cnpg.io/skipEmptyWalArchiveCheck: "enabled"
 spec:
   instances: 1
-  imageCatalogRef:
-    apiGroup: postgresql.cnpg.io
-    kind: ClusterImageCatalog
-    major: 17
-    name: postgresql
+  imageName: ghcr.io/cloudnative-pg/postgresql:17
   enableSuperuserAccess: true
   superuserSecret:
     name: lldap-pg-superuser


### PR DESCRIPTION
## Summary

- Replace `imageCatalogRef` with `imageName: ghcr.io/cloudnative-pg/postgresql:17` in both CNPG clusters
- The referenced `ClusterImageCatalog` named `postgresql` doesn't exist, blocking cluster creation
- Direct `imageName` gives per-cluster control over PG version

🤖 Generated with [Claude Code](https://claude.com/claude-code)