### PR TITLE
fix(auth): add writable /data volume for lldap

### DIFF
--- a/kubernetes/apps/auth/lldap/app/helmrelease.yaml
+++ b/kubernetes/apps/auth/lldap/app/helmrelease.yaml
@@ -77,6 +77,11 @@ spec:
             port: *ldap
           http:
             port: *http
+    persistence:
+      data:
+        type: emptyDir
+        globalMounts:
+          - path: /data
     route:
       app:
         hostnames:


### PR DESCRIPTION
## Summary

- Add emptyDir mount at `/data` for lldap
- lldap writes its default config to `/data/lldap_config.toml` at startup, which fails with `readOnlyRootFilesystem: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)