### PR TITLE
fix(auth): disable readOnlyRootFilesystem for lldap

### DIFF
--- a/kubernetes/apps/auth/lldap/app/helmrelease.yaml
+++ b/kubernetes/apps/auth/lldap/app/helmrelease.yaml
@@ -57,7 +57,7 @@ spec:
               readiness: *probes
             securityContext:
               allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: true
+              readOnlyRootFilesystem: false
               capabilities: { drop: ["ALL"] }
             resources:
               requests:


### PR DESCRIPTION
## Summary

- Set `readOnlyRootFilesystem: false` for lldap
- lldap chowns `/app` and `/app/bootstrap` at startup — these are application directories in the container image, so emptyDir would hide the binaries
- Other security settings retained (no privilege escalation, all capabilities dropped, non-root user)

🤖 Generated with [Claude Code](https://claude.com/claude-code)