### PR TITLE
fix(auth): use YAML block scalar for OIDC JWKS key

### DIFF
--- a/kubernetes/apps/auth/authelia/app/resources/configuration.yml
+++ b/kubernetes/apps/auth/authelia/app/resources/configuration.yml
@@ -90,7 +90,8 @@ identity_providers:
     jwks:
       - algorithm: 'RS256'
         use: 'sig'
-        key: '{{ secret "/secrets/authelia/OIDC_JWKS_KEY" }}'
+        key: |
+{{ secret "/secrets/authelia/OIDC_JWKS_KEY" | indent 10 }}
     lifespans:
       access_token: 1h
       authorize_code: 1m


### PR DESCRIPTION
## Summary

- Fix OIDC JWKS key parsing error: `could not decode to a schema.CryptographicKey illegal base64 data at input byte 0`
- The PEM private key is multi-line — expanding it inline with `{{ secret }}` in a single-quoted YAML string breaks parsing
- Use a YAML block scalar (`|`) with `indent 10` so the multi-line PEM key is properly formatted after template expansion

🤖 Generated with [Claude Code](https://claude.com/claude-code)