### PR TITLE
fix(auth): allow lldap to run as root for entrypoint chown

### DIFF
--- a/kubernetes/apps/auth/lldap/app/helmrelease.yaml
+++ b/kubernetes/apps/auth/lldap/app/helmrelease.yaml
@@ -66,11 +66,6 @@ spec:
                 cpu: 10m
               limits:
                 memory: 128Mi
-    defaultPodOptions:
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
-        runAsGroup: 1000
     service:
       app:
         controller: lldap


### PR DESCRIPTION
## Summary

- Remove `runAsNonRoot: true`, `runAsUser: 1000`, `runAsGroup: 1000` from lldap pod security context
- lldap's entrypoint runs `chown` on `/app` and `/app/bootstrap` then drops privileges itself
- Container-level security (no privilege escalation, capabilities dropped) still applies

After merging, you'll need to clear the failed Helm release:
```
flux suspend hr lldap -n auth
helm uninstall lldap -n auth
flux resume hr lldap -n auth
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)