### PR TITLE
fix(auth): enable authelia config template filter

### DIFF
--- a/kubernetes/apps/auth/authelia/app/helmrelease.yaml
+++ b/kubernetes/apps/auth/authelia/app/helmrelease.yaml
@@ -20,6 +20,7 @@ spec:
               tag: 4.39.15
             env:
               TZ: America/Chicago
+              X_AUTHELIA_CONFIG_FILTERS: template
               AUTHELIA_SERVER_ADDRESS: "tcp4://:9091"
               AUTHELIA_SERVER_DISABLE_HEALTHCHECK: "true"
               AUTHELIA_TELEMETRY_METRICS_ENABLED: "true"

--- a/kubernetes/apps/auth/authelia/app/resources/configuration.yml
+++ b/kubernetes/apps/auth/authelia/app/resources/configuration.yml
@@ -91,7 +91,7 @@ identity_providers:
       - algorithm: 'RS256'
         use: 'sig'
         key: |
-{{ secret "/secrets/authelia/OIDC_JWKS_KEY" | indent 10 }}
+          {{ secret "/secrets/authelia/OIDC_JWKS_KEY" | mindent 10 "|" | msquote }}
     lifespans:
       access_token: 1h
       authorize_code: 1m


### PR DESCRIPTION
## Summary
- Add `X_AUTHELIA_CONFIG_FILTERS: template` env var to enable authelia's Go template processing on `configuration.yml`
- Fix OIDC JWKS key template to use `mindent`/`msquote` filters for proper multi-line PEM key handling

Without the config filter enabled, authelia treats `{{ secret }}` calls as literal text, which breaks YAML parsing on the multi-line JWKS key (line 94) and prevents the entire config from loading.

Reference: [Diaoul/home-ops authelia config](https://github.com/Diaoul/home-ops/blob/main/kubernetes/apps/security/authelia/app/resources/configuration.yaml) uses the same pattern.

## Test plan
- [ ] Verify authelia pod starts without YAML parse errors
- [ ] Verify `{{ secret }}` templates resolve (LDAP, SMTP, OIDC secrets)
- [ ] Verify OIDC JWKS key loads correctly (no base64 decode errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)