### PR TITLE
fix(database): use garage.internal for CNPG S3 backup endpoint

### DIFF
--- a/kubernetes/apps/auth/authelia/db/cluster.yaml
+++ b/kubernetes/apps/auth/authelia/db/cluster.yaml
@@ -65,7 +65,7 @@ spec:
   retentionPolicy: "15d"
   configuration:
     destinationPath: "s3://cnpg/authelia/"
-    endpointURL: "http://snotra.internal:3900"
+    endpointURL: "http://garage.internal:3900"
     s3Credentials:
       region:
         name: authelia-cnpg-secret

--- a/kubernetes/apps/auth/lldap/db/cluster.yaml
+++ b/kubernetes/apps/auth/lldap/db/cluster.yaml
@@ -65,7 +65,7 @@ spec:
   retentionPolicy: "15d"
   configuration:
     destinationPath: "s3://cnpg/lldap/"
-    endpointURL: "http://snotra.internal:3900"
+    endpointURL: "http://garage.internal:3900"
     s3Credentials:
       region:
         name: lldap-cnpg-secret

--- a/kubernetes/components/cnpg-cluster/objectstore.yaml
+++ b/kubernetes/components/cnpg-cluster/objectstore.yaml
@@ -7,7 +7,7 @@ spec:
   retentionPolicy: "${CNPG_RETENTION:=15d}"
   configuration:
     destinationPath: "s3://cnpg/${APP}/"
-    endpointURL: "http://snotra.internal:3900"
+    endpointURL: "http://garage.internal:3900"
     s3Credentials:
       region:
         name: "${APP}-cnpg-secret"


### PR DESCRIPTION
## Summary
- Update S3 endpoint URL from `snotra.internal:3900` to `garage.internal:3900` in all three ObjectStore configs
- `snotra.internal` resolves to the NAS host, not the Garage S3 service
- `garage.internal` has a dedicated DNS override pointing to the correct IP

Affected files:
- `kubernetes/apps/auth/lldap/db/cluster.yaml`
- `kubernetes/apps/auth/authelia/db/cluster.yaml`
- `kubernetes/components/cnpg-cluster/objectstore.yaml`

## Test plan
- [ ] Delete failed backups: `kubectl delete backups -n auth --all`
- [ ] Verify new backups succeed: `kubectl get backups -n auth`

🤖 Generated with [Claude Code](https://claude.com/claude-code)