### PR TITLE
feat(media): add media stack with BookLore, Audiobookshelf, Shelfmark, Prowlarr, and Deluge

### DIFF
--- a/kubernetes/apps/auth/authelia/app/externalsecret.yaml
+++ b/kubernetes/apps/auth/authelia/app/externalsecret.yaml
@@ -18,6 +18,7 @@ spec:
         LDAP_PASSWORD: "{{ .LDAP_PASSWORD }}"
         OIDC_JWKS_KEY: "{{ .OIDC_JWKS_KEY }}"
         AUDIOBOOKSHELF_CLIENT_SECRET: "{{ .AUDIOBOOKSHELF_CLIENT_SECRET }}"
+        SHELFMARK_CLIENT_SECRET: "{{ .SHELFMARK_CLIENT_SECRET }}"
         SMTP_USERNAME: "{{ .SMTP_USERNAME }}"
         LDAP_BASE_DN: "{{ .LDAP_BASE_DN }}"
   data:
@@ -42,6 +43,9 @@ spec:
     - secretKey: AUDIOBOOKSHELF_CLIENT_SECRET
       remoteRef:
         key: "ebb701cf-3146-4ad6-836f-b3fa008ff08a"
+    - secretKey: SHELFMARK_CLIENT_SECRET
+      remoteRef:
+        key: "c21b8ed7-d196-4436-8b41-b3fd007e49e6"
     - secretKey: SMTP_USERNAME
       remoteRef:
         key: "bd706631-16f1-481d-aeb0-b3fa00901c85"

--- a/kubernetes/apps/auth/authelia/app/resources/configuration.yml
+++ b/kubernetes/apps/auth/authelia/app/resources/configuration.yml
@@ -5,7 +5,7 @@ server:
   address: 'tcp4://:9091'
   buffers:
     write: 4096
-    read: 4096
+    read: 8192
 
 log:
   level: warn
@@ -122,3 +122,30 @@ identity_providers:
           - 'https://audiobookshelf.${SECRET_DOMAIN}/auth/openid/callback'
           - 'https://audiobookshelf.${SECRET_DOMAIN}/auth/openid/mobile-redirect'
           - 'audiobookshelf://oauth'
+      - client_id: booklore
+        client_name: BookLore
+        public: true
+        authorization_policy: one_factor
+        consent_mode: implicit
+        scopes:
+          - openid
+          - offline_access
+          - profile
+          - email
+        redirect_uris:
+          - 'https://books.${SECRET_DOMAIN}/api/oidc'
+        token_endpoint_auth_method: none
+        pkce_challenge_method: S256
+      - client_id: shelfmark
+        client_name: Shelfmark
+        client_secret: '{{ secret "/secrets/authelia/SHELFMARK_CLIENT_SECRET" }}'
+        public: false
+        authorization_policy: one_factor
+        consent_mode: implicit
+        scopes:
+          - openid
+          - groups
+          - email
+          - profile
+        redirect_uris:
+          - 'https://shelfmark.${SECRET_DOMAIN}/oauth2/callback'

--- a/kubernetes/apps/media/audiobookshelf/app/helmrelease.yaml
+++ b/kubernetes/apps/media/audiobookshelf/app/helmrelease.yaml
@@ -1,0 +1,86 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: audiobookshelf
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 1h
+  values:
+    controllers:
+      audiobookshelf:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/advplyr/audiobookshelf
+              tag: 2.19.5
+            env:
+              TZ: America/Chicago
+              PORT: &port 80
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthcheck
+                    port: *port
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+              readiness: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 50m
+              limits:
+                memory: 512Mi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+    service:
+      app:
+        controller: audiobookshelf
+        ports:
+          http:
+            primary: true
+            port: *port
+    route:
+      app:
+        hostnames:
+          - "audiobookshelf.${SECRET_DOMAIN}"
+        parentRefs:
+          - name: envoy-external
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: *port
+    persistence:
+      config:
+        existingClaim: audiobookshelf
+        globalMounts:
+          - path: /config
+      metadata:
+        existingClaim: audiobookshelf
+        globalMounts:
+          - path: /metadata
+            subPath: metadata
+      audiobooks:
+        type: nfs
+        server: snotra.internal
+        path: /mnt/user/media/audiobooks
+        globalMounts:
+          - path: /audiobooks

--- a/kubernetes/apps/media/audiobookshelf/app/kustomization.yaml
+++ b/kubernetes/apps/media/audiobookshelf/app/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/apps/media/audiobookshelf/ks.yaml
+++ b/kubernetes/apps/media/audiobookshelf/ks.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app audiobookshelf
+  namespace: &namespace media
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/gatus/external
+    - ../../../../components/volsync
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  interval: 1h
+  path: ./kubernetes/apps/media/audiobookshelf/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 5Gi
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false

--- a/kubernetes/apps/media/booklore/app/externalsecret.yaml
+++ b/kubernetes/apps/media/booklore/app/externalsecret.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: booklore
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: bitwarden-secretsmanager
+  target:
+    name: booklore-secret
+    template:
+      data:
+        MARIADB_PASSWORD: "{{ .MARIADB_PASSWORD }}"
+  data:
+    - secretKey: MARIADB_PASSWORD
+      remoteRef:
+        key: "bd120844-2e88-4320-990b-b3fd007dfd5d"

--- a/kubernetes/apps/media/booklore/app/helmrelease.yaml
+++ b/kubernetes/apps/media/booklore/app/helmrelease.yaml
@@ -1,0 +1,87 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: booklore
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 1h
+  values:
+    controllers:
+      booklore:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/booklore-app/booklore
+              tag: v2.0.2
+            env:
+              TZ: America/Chicago
+              SPRING_DATASOURCE_URL: "jdbc:mariadb://mariadb.media.svc.cluster.local:3306/booklore"
+              SPRING_DATASOURCE_USERNAME: booklore
+              SPRING_DATASOURCE_PASSWORD:
+                valueFrom:
+                  secretKeyRef:
+                    name: booklore-secret
+                    key: MARIADB_PASSWORD
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: &port 6060
+                  initialDelaySeconds: 30
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+              readiness: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 100m
+              limits:
+                memory: 2Gi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+    service:
+      app:
+        controller: booklore
+        ports:
+          http:
+            primary: true
+            port: *port
+    route:
+      app:
+        hostnames:
+          - "books.${SECRET_DOMAIN}"
+        parentRefs:
+          - name: envoy-external
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: *port
+    persistence:
+      config:
+        existingClaim: booklore
+        globalMounts:
+          - path: /config
+      books:
+        type: nfs
+        server: snotra.internal
+        path: /mnt/user/media/books
+        globalMounts:
+          - path: /books

--- a/kubernetes/apps/media/booklore/app/kustomization.yaml
+++ b/kubernetes/apps/media/booklore/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./externalsecret.yaml

--- a/kubernetes/apps/media/booklore/ks.yaml
+++ b/kubernetes/apps/media/booklore/ks.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app booklore
+  namespace: &namespace media
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/gatus/external
+    - ../../../../components/volsync
+  dependsOn:
+    - name: mariadb
+      namespace: media
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  interval: 1h
+  path: ./kubernetes/apps/media/booklore/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+    substitute:
+      APP: *app
+      GATUS_SUBDOMAIN: books
+      VOLSYNC_CAPACITY: 5Gi
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false

--- a/kubernetes/apps/media/deluge/app/externalsecret.yaml
+++ b/kubernetes/apps/media/deluge/app/externalsecret.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: deluge
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: bitwarden-secretsmanager
+  target:
+    name: deluge-secret
+    template:
+      data:
+        VPN_SERVICE_PROVIDER: airvpn
+        WIREGUARD_PRIVATE_KEY: "{{ .WIREGUARD_PRIVATE_KEY }}"
+        WIREGUARD_PRESHARED_KEY: "{{ .WIREGUARD_PRESHARED_KEY }}"
+        WIREGUARD_ADDRESSES: "{{ .WIREGUARD_ADDRESSES }}"
+        SERVER_COUNTRIES: "{{ .SERVER_COUNTRIES }}"
+        DELUGE_PASSWORD: "{{ .DELUGE_PASSWORD }}"
+  data:
+    - secretKey: WIREGUARD_PRIVATE_KEY
+      remoteRef:
+        key: "fc5241cd-35c7-4b3f-9af2-b3fd007c8bcc"
+    - secretKey: WIREGUARD_PRESHARED_KEY
+      remoteRef:
+        key: "73a78fc9-9ff5-4186-adb3-b3fd007cb78e"
+    - secretKey: WIREGUARD_ADDRESSES
+      remoteRef:
+        key: "bf9d5113-16bb-4408-9950-b3fd007cda46"
+    - secretKey: SERVER_COUNTRIES
+      remoteRef:
+        key: "ba4cb37a-3fe4-428b-88c6-b3fd007d0adf"
+    - secretKey: DELUGE_PASSWORD
+      remoteRef:
+        key: "cb5f2336-4c47-46a6-a7cb-b3fd007d5249"

--- a/kubernetes/apps/media/deluge/app/helmrelease.yaml
+++ b/kubernetes/apps/media/deluge/app/helmrelease.yaml
@@ -1,0 +1,143 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: deluge
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 1h
+  values:
+    controllers:
+      deluge:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            dependsOn: gluetun
+            image:
+              repository: ghcr.io/onedr0p/deluge
+              tag: 2.1.1
+            env:
+              TZ: America/Chicago
+              DELUGE_LOGLEVEL: info
+              DELUGE_WEB_PORT: &port 8112
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: *port
+                  initialDelaySeconds: 30
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+              readiness: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 50m
+              limits:
+                memory: 1Gi
+          gluetun:
+            image:
+              repository: ghcr.io/qdm12/gluetun
+              tag: v3.40.0
+            env:
+              TZ: America/Chicago
+              VPN_TYPE: wireguard
+              DOT: "off"
+              FIREWALL_VPN_INPUT_PORTS: "58846"
+            envFrom:
+              - secretRef:
+                  name: deluge-secret
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /v1/openvpn/status
+                    port: 8000
+                  initialDelaySeconds: 10
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                add: ["NET_ADMIN"]
+                drop: ["ALL"]
+            resources:
+              requests:
+                cpu: 10m
+              limits:
+                memory: 256Mi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: false
+        runAsUser: 0
+        runAsGroup: 0
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+    service:
+      app:
+        controller: deluge
+        ports:
+          http:
+            primary: true
+            port: *port
+    route:
+      app:
+        hostnames:
+          - "deluge.${SECRET_DOMAIN}"
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: *port
+    persistence:
+      config:
+        existingClaim: deluge
+        advancedMounts:
+          deluge:
+            app:
+              - path: /config
+      downloads:
+        type: nfs
+        server: snotra.internal
+        path: /mnt/disks/85AAZU6GS/cluster/downloads
+        advancedMounts:
+          deluge:
+            app:
+              - path: /downloads
+      books:
+        type: nfs
+        server: snotra.internal
+        path: /mnt/user/media/books
+        advancedMounts:
+          deluge:
+            app:
+              - path: /books
+      audiobooks:
+        type: nfs
+        server: snotra.internal
+        path: /mnt/user/media/audiobooks
+        advancedMounts:
+          deluge:
+            app:
+              - path: /audiobooks
+      gluetun-data:
+        type: emptyDir
+        advancedMounts:
+          deluge:
+            gluetun:
+              - path: /tmp/gluetun

--- a/kubernetes/apps/media/deluge/app/kustomization.yaml
+++ b/kubernetes/apps/media/deluge/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./externalsecret.yaml

--- a/kubernetes/apps/media/deluge/ks.yaml
+++ b/kubernetes/apps/media/deluge/ks.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app deluge
+  namespace: &namespace media
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/gatus/guarded
+    - ../../../../components/volsync
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+    - name: external-secrets
+      namespace: external-secrets
+  interval: 1h
+  path: ./kubernetes/apps/media/deluge/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 5Gi
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false

--- a/kubernetes/apps/media/kustomization.yaml
+++ b/kubernetes/apps/media/kustomization.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: media
+components:
+  - ../../components/common
+resources:
+  - ./mariadb/ks.yaml
+  - ./audiobookshelf/ks.yaml
+  - ./booklore/ks.yaml
+  - ./prowlarr/ks.yaml
+  - ./deluge/ks.yaml
+  - ./shelfmark/ks.yaml

--- a/kubernetes/apps/media/mariadb/app/externalsecret.yaml
+++ b/kubernetes/apps/media/mariadb/app/externalsecret.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: mariadb
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: bitwarden-secretsmanager
+  target:
+    name: mariadb-secret
+    template:
+      data:
+        MARIADB_ROOT_PASSWORD: "{{ .MARIADB_ROOT_PASSWORD }}"
+        MARIADB_PASSWORD: "{{ .MARIADB_PASSWORD }}"
+  data:
+    - secretKey: MARIADB_ROOT_PASSWORD
+      remoteRef:
+        key: "00df0c47-3267-4500-b0e0-b3fd007de4d6"
+    - secretKey: MARIADB_PASSWORD
+      remoteRef:
+        key: "bd120844-2e88-4320-990b-b3fd007dfd5d"

--- a/kubernetes/apps/media/mariadb/app/helmrelease.yaml
+++ b/kubernetes/apps/media/mariadb/app/helmrelease.yaml
@@ -1,0 +1,78 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: mariadb
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 1h
+  values:
+    controllers:
+      mariadb:
+        type: statefulset
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: mariadb
+              tag: 11.7.2
+            env:
+              TZ: America/Chicago
+              MARIADB_DATABASE: booklore
+              MARIADB_USER: booklore
+              MARIADB_ROOT_PASSWORD:
+                valueFrom:
+                  secretKeyRef:
+                    name: mariadb-secret
+                    key: MARIADB_ROOT_PASSWORD
+              MARIADB_PASSWORD:
+                valueFrom:
+                  secretKeyRef:
+                    name: mariadb-secret
+                    key: MARIADB_PASSWORD
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  exec:
+                    command: ["healthcheck.sh", "--connect", "--innodb_initialized"]
+                  initialDelaySeconds: 30
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  exec:
+                    command: ["healthcheck.sh", "--connect", "--innodb_initialized"]
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+            resources:
+              requests:
+                cpu: 50m
+              limits:
+                memory: 512Mi
+    defaultPodOptions:
+      securityContext:
+        runAsUser: 999
+        runAsGroup: 999
+        fsGroup: 999
+        fsGroupChangePolicy: OnRootMismatch
+    service:
+      app:
+        controller: mariadb
+        ports:
+          mysql:
+            port: 3306
+    persistence:
+      data:
+        existingClaim: mariadb
+        globalMounts:
+          - path: /var/lib/mysql

--- a/kubernetes/apps/media/mariadb/app/kustomization.yaml
+++ b/kubernetes/apps/media/mariadb/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./externalsecret.yaml

--- a/kubernetes/apps/media/mariadb/ks.yaml
+++ b/kubernetes/apps/media/mariadb/ks.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app mariadb
+  namespace: &namespace media
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/volsync
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+    - name: external-secrets
+      namespace: external-secrets
+  interval: 1h
+  path: ./kubernetes/apps/media/mariadb/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 5Gi
+      VOLSYNC_PUID: "999"
+      VOLSYNC_PGID: "999"
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: true

--- a/kubernetes/apps/media/prowlarr/app/externalsecret.yaml
+++ b/kubernetes/apps/media/prowlarr/app/externalsecret.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: prowlarr
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: bitwarden-secretsmanager
+  target:
+    name: prowlarr-secret
+    template:
+      data:
+        PROWLARR__AUTH__APIKEY: "{{ .PROWLARR_API_KEY }}"
+  data:
+    - secretKey: PROWLARR_API_KEY
+      remoteRef:
+        key: "e91cbf49-c0b5-489e-a18e-b3fd007e3015"

--- a/kubernetes/apps/media/prowlarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/prowlarr/app/helmrelease.yaml
@@ -1,0 +1,88 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: prowlarr
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 1h
+  values:
+    controllers:
+      prowlarr:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/onedr0p/prowlarr-develop
+              tag: 1.31.2.4975
+            env:
+              TZ: America/Chicago
+              PROWLARR__APP__INSTANCENAME: Prowlarr
+              PROWLARR__AUTH__METHOD: External
+              PROWLARR__AUTH__REQUIRED: DisabledForLocalAddresses
+              PROWLARR__SERVER__PORT: &port 80
+              PROWLARR__LOG__LEVEL: info
+              PROWLARR__APP__THEME: dark
+            envFrom:
+              - secretRef:
+                  name: prowlarr-secret
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /ping
+                    port: *port
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+              readiness: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 10m
+              limits:
+                memory: 512Mi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+    service:
+      app:
+        controller: prowlarr
+        ports:
+          http:
+            primary: true
+            port: *port
+    route:
+      app:
+        hostnames:
+          - "prowlarr.${SECRET_DOMAIN}"
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: *port
+    persistence:
+      config:
+        existingClaim: prowlarr
+        globalMounts:
+          - path: /config
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/media/prowlarr/app/kustomization.yaml
+++ b/kubernetes/apps/media/prowlarr/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./externalsecret.yaml

--- a/kubernetes/apps/media/prowlarr/ks.yaml
+++ b/kubernetes/apps/media/prowlarr/ks.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app prowlarr
+  namespace: &namespace media
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/gatus/guarded
+    - ../../../../components/volsync
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  interval: 1h
+  path: ./kubernetes/apps/media/prowlarr/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 5Gi
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false

--- a/kubernetes/apps/media/shelfmark/app/externalsecret.yaml
+++ b/kubernetes/apps/media/shelfmark/app/externalsecret.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: shelfmark
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: bitwarden-secretsmanager
+  target:
+    name: shelfmark-secret
+    template:
+      data:
+        PROWLARR_API_KEY: "{{ .PROWLARR_API_KEY }}"
+        DELUGE_PASSWORD: "{{ .DELUGE_PASSWORD }}"
+  data:
+    - secretKey: PROWLARR_API_KEY
+      remoteRef:
+        key: "e91cbf49-c0b5-489e-a18e-b3fd007e3015"
+    - secretKey: DELUGE_PASSWORD
+      remoteRef:
+        key: "cb5f2336-4c47-46a6-a7cb-b3fd007d5249"

--- a/kubernetes/apps/media/shelfmark/app/helmrelease.yaml
+++ b/kubernetes/apps/media/shelfmark/app/helmrelease.yaml
@@ -1,0 +1,83 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: shelfmark
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 1h
+  values:
+    controllers:
+      shelfmark:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/calibrain/shelfmark
+              tag: v1.0.2
+            env:
+              TZ: America/Chicago
+            envFrom:
+              - secretRef:
+                  name: shelfmark-secret
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: &port 8084
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+              readiness: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 10m
+              limits:
+                memory: 512Mi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+    service:
+      app:
+        controller: shelfmark
+        ports:
+          http:
+            primary: true
+            port: *port
+    route:
+      app:
+        hostnames:
+          - "shelfmark.${SECRET_DOMAIN}"
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: *port
+    persistence:
+      config:
+        existingClaim: shelfmark
+        globalMounts:
+          - path: /config
+      downloads:
+        type: nfs
+        server: snotra.internal
+        path: /mnt/disks/85AAZU6GS/cluster/downloads
+        globalMounts:
+          - path: /downloads

--- a/kubernetes/apps/media/shelfmark/app/kustomization.yaml
+++ b/kubernetes/apps/media/shelfmark/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./externalsecret.yaml

--- a/kubernetes/apps/media/shelfmark/ks.yaml
+++ b/kubernetes/apps/media/shelfmark/ks.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app shelfmark
+  namespace: &namespace media
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/gatus/guarded
+    - ../../../../components/volsync
+  dependsOn:
+    - name: prowlarr
+      namespace: media
+    - name: deluge
+      namespace: media
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  interval: 1h
+  path: ./kubernetes/apps/media/shelfmark/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 5Gi
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false


### PR DESCRIPTION
## Summary

- Adds a new `media` namespace with 6 applications for ebook/audiobook management and automated downloads
- **MariaDB** — StatefulSet with volsync backup, serves as BookLore's database
- **Audiobookshelf** — Audiobook management with NFS library mount, external access, existing Authelia OIDC client
- **BookLore** — Ebook management replacing calibre-web, with Kobo sync, automated metadata, MariaDB backend, NFS book library, external access
- **Prowlarr** — Indexer management, internal access only
- **Deluge + Gluetun** — Torrent client with AirVPN WireGuard VPN sidecar, NFS mounts for downloads + library paths, internal access
- **Shelfmark** — Book request/download tool integrating Prowlarr + Deluge for acquisition pipeline, internal access
- Updates Authelia with BookLore (PKCE public) and Shelfmark OIDC clients
- Increases Authelia read buffer to 8192 for Kobo sync `X-Kobo-Synctoken` header compatibility

## Download Pipeline

```
Shelfmark (request) → Prowlarr (search) → Deluge (download via VPN)
  → NFS scratch: snotra.internal:/mnt/disks/85AAZU6GS/cluster/downloads
  → Move to /mnt/user/media/books or /mnt/user/media/audiobooks
  → BookLore / Audiobookshelf auto-imports
```

## Test plan

- [ ] Create `/mnt/disks/85AAZU6GS/cluster/downloads` on snotra NFS
- [ ] Verify NFS exports allow cluster node access to all media paths
- [ ] Verify all ExternalSecrets sync from Bitwarden
- [ ] MariaDB starts and creates `booklore` database
- [ ] Gluetun establishes WireGuard tunnel (check logs, verify VPN IP)
- [ ] Audiobookshelf accessible at `audiobookshelf.${SECRET_DOMAIN}`, OIDC login works
- [ ] BookLore accessible at `books.${SECRET_DOMAIN}`, OIDC login works, NFS library visible
- [ ] Prowlarr accessible internally, configure indexers
- [ ] Deluge accessible internally, verify VPN routing
- [ ] Shelfmark accessible internally, connect to Prowlarr + Deluge
- [ ] End-to-end: request book in Shelfmark → downloads via Deluge → appears in library

🤖 Generated with [Claude Code](https://claude.com/claude-code)