### PR TITLE
fix(media): use linuxserver deluge image

### DIFF
--- a/kubernetes/apps/media/deluge/app/helmrelease.yaml
+++ b/kubernetes/apps/media/deluge/app/helmrelease.yaml
@@ -17,12 +17,15 @@ spec:
           app:
             dependsOn: gluetun
             image:
-              repository: ghcr.io/onedr0p/deluge
+              repository: lscr.io/linuxserver/deluge
               tag: 2.1.1
             env:
               TZ: America/Chicago
+              PUID: "1000"
+              PGID: "1000"
               DELUGE_LOGLEVEL: info
-              DELUGE_WEB_PORT: &port 8112
+            ports:
+              - containerPort: &port 8112
             probes:
               liveness: &probes
                 enabled: true


### PR DESCRIPTION
## Summary

- Switch Deluge image from non-existent `ghcr.io/onedr0p/deluge` to `lscr.io/linuxserver/deluge`
- Add `PUID`/`PGID` env vars used by LinuxServer images

## Test plan

- [ ] Deluge pod starts successfully with the LinuxServer image
- [ ] Web UI accessible on port 8112

🤖 Generated with [Claude Code](https://claude.com/claude-code)