### PR TITLE
fix(media): NFS mount scoping and shelfmark permissions

### DIFF
--- a/kubernetes/apps/media/deluge/app/helmrelease.yaml
+++ b/kubernetes/apps/media/deluge/app/helmrelease.yaml
@@ -122,6 +122,7 @@ spec:
           deluge:
             app:
               - path: /downloads
+                subPath: cluster/downloads
       media:
         type: nfs
         server: snotra.internal

--- a/kubernetes/apps/media/shelfmark/app/helmrelease.yaml
+++ b/kubernetes/apps/media/shelfmark/app/helmrelease.yaml
@@ -46,9 +46,9 @@ spec:
                 memory: 512Mi
     defaultPodOptions:
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
-        runAsGroup: 1000
+        runAsNonRoot: false
+        runAsUser: 0
+        runAsGroup: 0
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
     service:


### PR DESCRIPTION
## Summary
- Add `subPath: cluster/downloads` to Deluge's NFS downloads mount so it only accesses the intended subfolder instead of chowning the entire disk
- Run Shelfmark as root so its entrypoint can create users/groups and configure timezone before dropping privileges via `sudo -E`

## Test plan
- [ ] Deluge pod starts without recursively chowning `/mnt/disks/85AAZU6GS`
- [ ] Shelfmark pod starts without permission denied errors on `/etc/localtime` or `groupadd`
- [ ] Downloads still work end-to-end between Deluge and Shelfmark

🤖 Generated with [Claude Code](https://claude.com/claude-code)