### PR TITLE
docs: upgrade triage for 41 pending renovate PRs

### DIFF
--- a/upgrade-triage/00-superseded-close.md
+++ b/upgrade-triage/00-superseded-close.md
@@ -1,0 +1,37 @@
+# Batch 0: Superseded PRs — Close Without Merging
+
+These PRs target older versions of the same component where a newer PR exists.
+They are NOT useful as intermediate stepping stones (those have been moved into
+their respective upgrade sequences in Batches 3 and 4).
+
+| PR | Title | Superseded By | Batch |
+|----|-------|---------------|-------|
+| #2 | Reflector 9.1.7 → 9.1.45 | #81 (→ 10.0.12) | Batch 1 |
+| #10 | kube-prometheus-stack 73.2.2 → 73.2.3 | #79 → #89 sequence | Batch 4 |
+| #28 | k8s-sidecar 1.30.3 → 1.30.11 | #65 (→ 2.5.0) | Batch 3 |
+| #33 | Minecraft chart 4.26.3 → 4.26.4 | #61 (→ 5.1.1) | Batch 2 |
+| #38 | Snapshot Controller 4.0.2 → 4.2.0 | #78 (→ 5.0.3) | Batch 2 |
+
+## Rescued as intermediate steps (moved to upgrade sequences)
+
+These were originally in this list but have been moved into their target batch
+as a required first step in a multi-major-version upgrade:
+
+| PR | Role | Sequence | Batch |
+|----|------|----------|-------|
+| #9 | Grafana 9.4.5 — checkpoint before Angular-breaking 10.x | #9 → #55 | Batch 3 |
+| #79 | kube-prometheus-stack 81.6.9 — bridge 73→81 before 81→82 | #79 → #89 | Batch 4 |
+| #24 | External Secrets 0.20.4 — stabilize on latest 0.x before 2.0 jump | #24 → #86 | Batch 4 |
+
+## Why close the remaining five?
+
+- **#2 (Reflector 9.1.45)**: v10.0.0 is a cosmetic major bump with zero code
+  changes. No gap to bridge — skip straight to #81.
+- **#10 (kps 73.2.3)**: Patch on current major. Doesn't bridge any version gap.
+  The meaningful intermediate is #79 (81.6.9), not a patch on 73.x.
+- **#28 (k8s-sidecar 1.30.11)**: Patch on current major. The v1→v2 breaking
+  changes (memory, health server) aren't mitigated by being on a newer 1.x patch.
+- **#33 (Minecraft 4.26.4)**: Patch on current major. The v4→v5 template naming
+  changes aren't mitigated by a 4.x patch.
+- **#38 (Snapshot Controller 4.2.0)**: Minor within 4.x. onedr0p merged 4.2→5.0
+  cleanly, and this intermediate adds no safety.

--- a/upgrade-triage/01-batch-immediate.md
+++ b/upgrade-triage/01-batch-immediate.md
@@ -1,0 +1,124 @@
+# Batch 1: Immediate Merges — No Prep Required
+
+Merge these in any order. All are patch bumps, cosmetic major bumps, or minor
+versions with no documented breaking changes. None required extra work when
+merged by onedr0p (where applicable).
+
+## PRs in this batch (15)
+
+### #87 — Reloader 2.2.7 → 2.2.8
+- **Risk**: Negligible (patch)
+- **Rating rationale**: Patch release with only bug fixes. Stakater Reloader is
+  a simple controller that watches ConfigMaps/Secrets and triggers rollouts.
+  Patch versions never change behavior.
+- **onedr0p**: Merged same version (#10496, Feb 13). No issues.
+- **Extra steps**: None.
+
+### #83 — mc-router 1.4.0 → 1.4.1
+- **Risk**: Negligible (patch)
+- **Rating rationale**: itzg mc-router Helm chart patch. Bug fixes only.
+- **onedr0p**: N/A (different stack).
+- **Extra steps**: None.
+
+### #64 — Promtail 6.17.0 → 6.17.1
+- **Risk**: Negligible (patch)
+- **Rating rationale**: Grafana Promtail chart patch release.
+- **onedr0p**: N/A (uses VictoriaLogs).
+- **Extra steps**: None.
+
+### #54 — tnu 0.4.3 → 0.4.4
+- **Risk**: Negligible (patch)
+- **Rating rationale**: jfroy/tnu patch release. Minimal blast radius.
+- **onedr0p**: N/A.
+- **Extra steps**: None.
+
+### #74 — cert-manager v1.19.2 → v1.19.4
+- **Risk**: Low (security patch)
+- **Rating rationale**: Contains fixes for CVE-2025-68121 and CVE-2026-24051.
+  Maintainers recommend all users upgrade. No behavior changes.
+- **onedr0p**: Merged through v1.19.3 (#10443) and v1.19.4 (#10556). No issues.
+- **Extra steps**: None.
+
+### #80 — Cloudflared container 2026.1.2 → 2026.2.0
+- **Risk**: Low (minor)
+- **Rating rationale**: Cloudflare tunnel daemon update. The `proxy-dns` feature
+  was removed in 2026.x but this repo doesn't use it. Security fixes included.
+- **onedr0p**: Merged same version (#10465, Feb 7). No issues.
+- **Extra steps**: None.
+
+### #82 — Cloudflared tool (mise) 2025.11.1 → 2026.2.0
+- **Risk**: Low (local tool only)
+- **Rating rationale**: Updates the local CLI tool version in `.mise.toml`. Does
+  not affect running cluster. Same codebase as #80.
+- **Extra steps**: None.
+
+### #81 — Reflector 9.1.7 → 10.0.12
+- **Risk**: Low (cosmetic major bump)
+- **Rating rationale**: Despite being a "major" version bump, v10.0.0 of
+  Emberstack Reflector changed ZERO application code. The v10.0.0 commit
+  (e367cd4) only bumped CI dependencies (GitHub Actions upload/download
+  artifact). All subsequent 10.0.x releases are also automated dependency bumps.
+  No Helm values changes, no API changes, no behavioral changes.
+- **onedr0p**: Not visible in recent PRs (may auto-merge or not use).
+- **Extra steps**: None.
+
+### #88 — Flux Operator 0.40.0 → 0.42.1
+- **Risk**: Low (minor)
+- **Rating rationale**: Additive features only. No breaking changes documented.
+- **onedr0p**: Merged multiple flux-operator updates through Feb. Also did a
+  separate "add anon auth to flux operator" chore (#10561) adding a
+  ClusterRoleBinding — check if you need the same.
+- **Extra steps**: Review whether you need an anonymous auth ClusterRoleBinding
+  similar to onedr0p's #10561. If your Flux setup requires anonymous access to
+  OCI registries, you may need this.
+
+### #13 — app-template 4.0.1 → 4.6.2
+- **Risk**: Low (minor within same major)
+- **Rating rationale**: bjw-s app-template chart. Minor version bumps within the
+  4.x line are additive (new features, helpers). No breaking changes.
+- **onedr0p**: Already at 4.6.2 (#10370, Jan 16). No issues.
+- **Extra steps**: None.
+
+### #29 — System Upgrade Controller v0.15.2 → v0.19.0
+- **Risk**: Low (minor)
+- **Rating rationale**: Rancher system-upgrade-controller. No breaking API
+  changes across this range. Incremental Kubernetes version compatibility.
+- **onedr0p**: N/A (different upgrade approach).
+- **Extra steps**: None.
+
+### #39 — Gatus v5.18.1 → v5.35.0
+- **Risk**: Low (17 minor versions, but no breaking changes documented)
+- **Rating rationale**: Large version range but Gatus v5.x maintains backward
+  compatibility. Config format unchanged. New features are additive (more
+  endpoint types, alerting providers).
+- **onedr0p**: Already at v5.35.0 (#10542, Feb 20). No issues.
+- **Extra steps**: Monitor UI and alerting after deploy to confirm dashboards
+  render correctly.
+
+### #71 — actions/checkout v4.3.1 → v6.0.2
+- **Risk**: Low (CI only)
+- **Rating rationale**: No functional API changes for callers. Internal change:
+  git credentials now stored in `$RUNNER_TEMP` instead of `$RUNNER_WORKSPACE`.
+  Transparent to workflows that just use `actions/checkout`.
+- **onedr0p**: N/A (different CI setup).
+- **Extra steps**: None.
+
+### #68 — flux-local v7.11.0 → v8.1.0
+- **Risk**: Low (CI only)
+- **Rating rationale**: Used as a GitHub Action (Docker image). Python version
+  requirement changed internally but doesn't affect Docker-based usage. CLI
+  arguments unchanged.
+- **onedr0p**: N/A.
+- **Extra steps**: None.
+
+### #53 — tj-actions/changed-files v46.0.5 → v47.0.4
+- **Risk**: Low (CI only) — BUT verify SHA
+- **Rating rationale**: No breaking changes in v47. However, this action had a
+  **supply chain attack in March 2025 (CVE-2025-30066)** where malicious code
+  was injected via a compromised maintainer token. The action was restored but
+  trust was damaged.
+- **onedr0p**: N/A.
+- **Extra steps**: **Verify the pinned SHA in the PR matches the official
+  tj-actions/changed-files v47.0.4 release tag.** Run:
+  `gh api repos/tj-actions/changed-files/git/ref/tags/v47.0.4 --jq '.object.sha'`
+  and compare to the SHA in the workflow file.

--- a/upgrade-triage/02-batch-light-prep.md
+++ b/upgrade-triage/02-batch-light-prep.md
@@ -1,0 +1,110 @@
+# Batch 2: Light Prep — Minor Config or Verification Before Merge
+
+These PRs are low risk but need a small config tweak, a value override, or a
+quick verification before or immediately after merging.
+
+## PRs in this batch (7)
+
+### #51 — actions/labeler v5.0.0 → v6.0.1
+- **Risk**: Low
+- **Rating rationale**: CI-only change. The only breaking change is that `dot:
+  true` is now the default (matches dotfiles in glob patterns). If your
+  `.github/labeler.yaml` uses glob patterns, labels may start matching dotfiles.
+- **onedr0p**: N/A.
+- **Extra steps before merge**: Review `.github/labeler.yaml` for any glob
+  patterns where matching dotfiles would be undesirable. If unsure, add
+  `dot: false` to any affected patterns to preserve v5 behavior.
+
+### #106 — NFS mount scoping and shelfmark permissions (community PR)
+- **Risk**: Low
+- **Rating rationale**: Manual PR from theiam79, not an automated dependency
+  bump. Small diff (9 additions, 5 deletions). Modifies NFS mount paths and
+  permissions for the media stack.
+- **onedr0p**: N/A (different contributor).
+- **Extra steps before merge**: Read the diff carefully. Verify the NFS paths
+  and permission changes match your NAS export configuration. Test that media
+  apps can still read/write after merge.
+
+### #78 — Snapshot Controller 4.0.2 → 5.0.3
+- **Risk**: Low-Medium
+- **Rating rationale**: Initially rated Medium due to CRD ownership annotation
+  concerns. **Downgraded after onedr0p evidence**: he merged 4.2.0 → 5.0.0
+  (#10349, Jan 14) cleanly with no visible drama, touching only the
+  HelmRelease and OCIRepository files. The breaking changes are RBAC-related
+  (Update→Patch operations) which Helm handles automatically.
+- **onedr0p**: Merged cleanly. Now on 5.0.3 (#10524).
+- **Extra steps before merge**: Verify your snapshot CRDs aren't manually
+  managed. If they are Helm-managed already, this should be seamless. If you see
+  CRD ownership errors after merge, annotate them:
+  ```bash
+  for crd in volumesnapshotclasses.snapshot.storage.k8s.io \
+              volumesnapshotcontents.snapshot.storage.k8s.io \
+              volumesnapshots.snapshot.storage.k8s.io; do
+    kubectl annotate crd "$crd" \
+      meta.helm.sh/release-name=snapshot-controller \
+      meta.helm.sh/release-namespace=kube-system --overwrite
+    kubectl label crd "$crd" \
+      app.kubernetes.io/managed-by=Helm --overwrite
+  done
+  ```
+
+### #84 — Envoy Gateway v1.6.3 → v1.7.0
+- **Risk**: Low-Medium
+- **Rating rationale**: Initially rated Medium. **Downgraded after onedr0p
+  evidence**: he merged this cleanly (#10458, Feb 5). He did prep work a week
+  earlier (#10267) removing connection buffer limit and timeout settings from
+  his envoy config.
+- **onedr0p**: Merged cleanly. Prep: removed deprecated envoy config values.
+- **Extra steps before merge**:
+  1. Review your envoy gateway config for any deprecated connection buffer or
+     timeout settings and remove them.
+  2. After merge, check Grafana dashboards — `stats_tags` metric names changed
+     in 1.7. Update any panels referencing old metric names.
+  3. Note: invalid HTTPRoute filters now return HTTP 500 instead of being
+     silently ignored. This surfaces latent config errors — check logs after
+     deploy.
+
+### #90 — SM-Operator 0.1.0 → 2.0.0
+- **Risk**: Low (with fix)
+- **Rating rationale**: Despite the large version number jump, the SM-Operator
+  2.0.0 release has no real breaking changes for users. However, the upgrade
+  will fail without a version constraint fix.
+- **onedr0p**: N/A.
+- **Extra steps before merge**: Your HelmRelease likely has a version constraint
+  like `>=0.1.0 <1.0.0` that will block the upgrade. Update the semver
+  constraint to `>=2.0.0 <3.0.0` (or remove it) before merging. Check with:
+  ```bash
+  grep -r "sm-operator" kubernetes/ --include="*.yaml" -l
+  ```
+  Then update the version constraint in the HelmRelease.
+
+### #37 — VolSync 0.12.1 → 0.14.0
+- **Risk**: Low-Medium
+- **Rating rationale**: The `kube-rbac-proxy` sidecar was removed in this range.
+  If you have `disableAuth: true` already set, this is a non-issue. The chart
+  also introduced new replication features but existing ReplicationSources/
+  Destinations are unaffected.
+- **onedr0p**: Uses a different VolSync fork (`perfectra1n/volsync` 0.18.x), so
+  no direct comparison. He did do a "chore: update volsync schedules" (#10554)
+  around the same time.
+- **Extra steps after merge**: Verify that Prometheus metrics scraping from
+  VolSync still works. If you relied on the kube-rbac-proxy for metrics auth,
+  you'll need to update your ServiceMonitor.
+
+### #14 — OpenEBS 4.2.0 → 4.4.0
+- **Risk**: Low-Medium (with fix)
+- **Rating rationale**: OpenEBS chart 4.3.0 introduced a bundled observability
+  stack (Loki, Alloy, MinIO) that is **enabled by default**. Without disabling
+  these, the upgrade will deploy unwanted pods that consume resources and
+  conflict with your existing Loki/monitoring stack.
+- **onedr0p**: N/A.
+- **Extra steps before merge**: Add these values to your OpenEBS HelmRelease
+  before or alongside the version bump:
+  ```yaml
+  loki:
+    enabled: false
+  alloy:
+    enabled: false
+  ```
+  Verify with `kubectl get pods -n openebs` after deploy that no unexpected
+  Loki/Alloy/MinIO pods appear.

--- a/upgrade-triage/03-batch-moderate-prep.md
+++ b/upgrade-triage/03-batch-moderate-prep.md
@@ -1,0 +1,140 @@
+# Batch 3: Moderate Prep — Config Changes and Testing Required
+
+These PRs require meaningful changes to Helm values, resource limits, or
+application config before merging. Each should be validated after deploy.
+
+## PRs in this batch (5)
+
+### #61 — Minecraft chart 4.26.3 → 5.1.1
+- **Risk**: Medium-Low
+- **Rating rationale**: Major chart version with template naming changes
+  (`nameOverride`/`fullnameOverride` behavior). Your servers likely don't set
+  these overrides, but the StatefulSet/Service names could change, which would
+  orphan existing PVCs.
+- **onedr0p**: N/A (not in his stack).
+- **Extra steps**:
+  1. Before merging, verify your minecraft HelmRelease values for
+     `nameOverride` and `fullnameOverride`. If unset, the defaults may change
+     resource names.
+  2. Check current resource names:
+     ```bash
+     kubectl get statefulset,svc,pvc -n <minecraft-namespace>
+     ```
+  3. After merge, verify PVCs are still bound and the server comes up with
+     world data intact.
+  4. If names changed, you may need to manually update PVC references or
+     create the new StatefulSet before deleting the old one.
+
+### #65 — k8s-sidecar 1.30.3 → 2.5.0
+- **Risk**: Medium-High
+- **Rating rationale**: k8s-sidecar v2 rewrote internals with significantly
+  higher memory usage (~135% increase, from ~80MB to 189MB+). This is confirmed
+  in upstream issues. Your Gatus init container uses a 128Mi memory limit which
+  **will OOM** on v2. Additionally, v2 adds a health server on port 8080 and
+  changes some environment variable names.
+- **onedr0p**: Not in his stack (uses `gatus-sidecar`, a different tool).
+- **Extra steps before merge**:
+  1. Find all containers using the k8s-sidecar image:
+     ```bash
+     grep -r "k8s-sidecar" kubernetes/ --include="*.yaml" -l
+     ```
+  2. Increase memory limits from 128Mi to at least 256Mi (recommend 300Mi for
+     headroom) on every container using this image.
+  3. Check for `readOnlyRootFilesystem: true` in security contexts — the new
+     health server may need write access to `/tmp`.
+  4. After merge, monitor pod memory usage for 24h:
+     ```bash
+     kubectl top pods -l <sidecar-label> --all-namespaces
+     ```
+  5. If any pods OOM, increase limits further. The v2 memory footprint scales
+     with the number of watched resources.
+
+### #36 — Loki chart 6.30.1 → 6.53.0
+- **Risk**: Medium-High
+- **Rating rationale**: Loki chart 6.38 introduced a breaking change where
+  `singleBinary.persistence.accessModes` became null by default, causing
+  StatefulSet patch failures. This is a known issue in the community. Without
+  the fix, the upgrade will hang as Flux cannot reconcile the StatefulSet.
+- **onedr0p**: Uses VictoriaLogs instead — no comparison available.
+- **Extra steps before merge**:
+  1. Add to your Loki HelmRelease values:
+     ```yaml
+     singleBinary:
+       persistence:
+         accessModes:
+           - ReadWriteOnce
+     ```
+     (or whatever access mode you currently use — check your existing
+     StatefulSet with `kubectl get sts -n <loki-ns> -o yaml | grep accessModes`)
+  2. This is a 23-minor-version jump. Review the Loki Helm chart changelog for
+     any config deprecations between 6.30 and 6.53. Key areas:
+     - Storage schema version changes
+     - `structuredConfig` vs flat values
+     - Memberlist/ring configuration
+  3. After merge, verify log ingestion and querying still work. Check Grafana
+     Explore with a simple LogQL query.
+
+### #9 then #55 — Grafana chart 9.2.2 → 9.4.5 → 10.5.15 (two-step sequence)
+
+This is a sequenced upgrade. Merge #9 first, verify, then merge #55.
+
+#### Step 1: #9 — Grafana chart 9.2.2 → 9.4.5
+- **Risk**: Low
+- **Rating rationale**: Minor bump within the same chart major. Same Grafana
+  application version (12.1.1). No Angular changes, no plugin compatibility
+  issues. This is a safe checkpoint that validates your Flux pipeline handles
+  Grafana chart upgrades correctly.
+- **Extra steps**: None. Merge and verify Grafana comes up and dashboards load.
+  If anything breaks here, it's a chart config issue you want to fix before
+  attempting the Angular-breaking 10.x jump.
+- **Wait**: Verify stability for at least a few hours before proceeding to #55.
+
+#### Step 2: #55 — Grafana chart 9.4.5 → 10.5.15
+- **Risk**: Medium-High
+- **Rating rationale**: Two major issues:
+  1. **Angular plugin removal**: Grafana fully removed Angular support. The
+     `natel-discrete-panel` and `vonage-status-panel` plugins are Angular-based
+     and **will not load** on Grafana 12.x (which chart 10.x ships). The
+     `GF_SECURITY_ANGULAR_SUPPORT_ENABLED` environment variable is also removed.
+  2. **Chart deprecation**: The `grafana/helm-charts/grafana` chart repo was
+     deprecated in January 2026. The chart moved to
+     `grafana-community/helm-charts`. This doesn't block the upgrade but means
+     future updates will come from a different source.
+- **onedr0p**: Uses grafana-operator (chart 5.22.0) instead — completely
+  different deployment model. No comparison available.
+- **Extra steps before merge**:
+  1. Identify and remove/replace Angular plugins:
+     ```bash
+     grep -r "natel-discrete-panel\|vonage-status-panel\|angular" \
+       kubernetes/ --include="*.yaml"
+     ```
+     Replace with React-based alternatives:
+     - `natel-discrete-panel` → `marcusolsson-dynamictext-panel` or native
+       State Timeline panel
+     - `vonage-status-panel` → `grafana-polystat-panel` or native Stat panel
+  2. Remove `GF_SECURITY_ANGULAR_SUPPORT_ENABLED` from environment variables.
+  3. Review all dashboards for Angular panel types. Any dashboard using removed
+     panels will show "Panel plugin not found" errors.
+  4. Plan the OCI source migration to `grafana-community/helm-charts` for
+     future updates.
+  5. After merge, walk through each Grafana dashboard to verify panels render.
+
+### #69 — Helm CLI 3.20.0 → 4.1.1 (mise tool)
+- **Risk**: Medium (local tooling only)
+- **Rating rationale**: Only affects the local `helm` binary in `.mise.toml`.
+  Does NOT affect Flux-managed HelmReleases in the cluster (Flux has its own
+  Helm library). However, Helm 4 changes defaults: server-side apply (SSA) is
+  the new default, `helm install` behavior changed for existing releases, and
+  some CLI flags were removed. If you use `helm` or `helmfile` for bootstrap
+  operations, this matters.
+- **onedr0p**: Not visible in his PRs — likely still on Helm 3. Helm 3 is
+  supported until November 2026, so there's no urgency.
+- **Extra steps before merge**:
+  1. Test your bootstrap helmfile with Helm 4:
+     ```bash
+     cd bootstrap && helmfile diff
+     ```
+  2. Check if any bootstrap scripts use removed Helm 3 flags.
+  3. If bootstrap breaks, keep Helm 3 for now — there's no urgency.
+  4. Consider running Helm 3 and 4 side-by-side during transition by pinning
+     the version per-task rather than globally.

--- a/upgrade-triage/04-batch-heavy-prep.md
+++ b/upgrade-triage/04-batch-heavy-prep.md
@@ -1,0 +1,161 @@
+# Batch 4: Heavy Prep — CRD Updates, Bootstrap Changes, Coordinated Upgrades
+
+These PRs touch core infrastructure and require updating bootstrap
+configurations, CRD manifests, or careful sequencing. Each upgrade should be
+done individually with monitoring between deploys.
+
+Both upgrades in this batch use a two-step sequence: merge an intermediate PR
+first to reduce the version gap, verify stability, then merge the target PR.
+
+## PRs in this batch (4, in 2 sequences)
+
+---
+
+### #79 then #89 — kube-prometheus-stack 73.x → 81.6.9 → 82.4.1 (two-step sequence)
+
+This is the highest-priority sequenced upgrade. onedr0p never skipped a kps
+major version. You are 9 majors behind. This sequence splits it into two jumps.
+
+#### Step 1: #79 — kube-prometheus-stack 73.x → 81.6.9
+- **Risk**: Medium-High (large jump, but landing on a well-tested version)
+- **Rating rationale**: This is still a significant jump (73→81, 8 major chart
+  versions), but 81.6.9 is a mature patch release that onedr0p ran for weeks
+  with dozens of incremental patches on top. It's a battle-tested landing point.
+  The CRDs at 81.x are a generation behind 82.x, meaning this step exercises
+  the CRD upgrade path without also taking on the 82.x Operator changes.
+
+  Key breaking changes across 73→81:
+  - PrometheusRule resource naming conventions changed.
+  - Prometheus Operator CRDs updated (scrape classes, PrometheusAgent, new
+    status subresources).
+  - Thanos sidecar configuration restructured.
+  - Default resource requests/limits changed.
+  - `additionalPrometheusRulesMap` key naming may affect your custom rules
+    (`dockerhub-rules`, `oom-rules`, `zfs-rules`).
+
+- **onedr0p**: Was on 80.14.4 when he jumped to 81.0.0 (Jan 16). He then rode
+  81.x for a full month through dozens of patches before jumping to 82.0.0.
+
+- **Extra steps**:
+  1. **Update bootstrap CRDs to 81.6.9 first**:
+     ```bash
+     # Edit bootstrap/helmfile.d/00-crds.yaml
+     # Set kube-prometheus-stack CRD version to 81.6.9
+     cd bootstrap && helmfile apply
+     ```
+  2. **Review your custom HelmRelease values** for deprecated keys between 73
+     and 81. Particularly:
+     - `additionalPrometheusRulesMap` structure
+     - `thanosRuler` section
+     - `prometheusOperator.admissionWebhooks`
+     - Any hardcoded image tags that may conflict
+  3. Merge PR #79.
+  4. **Check for orphaned PrometheusRules**:
+     ```bash
+     kubectl get prometheusrules --all-namespaces
+     ```
+     Delete any old-named rules no longer managed by the HelmRelease.
+  5. Verify:
+     - All Prometheus targets are scraping (Prometheus UI → Status → Targets)
+     - Alertmanager is receiving alerts
+     - Grafana dashboards with Prometheus datasource still render
+  6. **Wait at least 24 hours** on 81.6.9 before proceeding to Step 2.
+
+#### Step 2: #89 — kube-prometheus-stack 81.6.9 → 82.4.1
+- **Risk**: Medium (single major jump from a stable baseline)
+- **Rating rationale**: With 81.6.9 stable, this becomes a single major version
+  jump — the same size jump onedr0p made (81.6.9→82.0.0). The 82.x line brings
+  Prometheus Operator v0.89.0 CRD changes, but the delta from 81.x is much
+  smaller than from 73.x.
+
+- **onedr0p**: Merged 81.6.9→82.0.0 (#10512, Feb 15). The PR touched
+  `bootstrap/helmfile.d/00-crds.yaml` and the OCIRepository. He then rode 82.x
+  through 82.4.1 with no issues.
+
+- **Extra steps**:
+  1. **Update bootstrap CRDs to 82.4.1**:
+     ```bash
+     # Edit bootstrap/helmfile.d/00-crds.yaml
+     # Set kube-prometheus-stack CRD version to 82.4.1
+     cd bootstrap && helmfile apply
+     ```
+  2. Merge PR #89.
+  3. Verify same checklist as Step 1 (targets, alerts, dashboards).
+  4. Clean up: close PR #10 (73.2.3 patch) if still open — it's now irrelevant.
+
+---
+
+### #24 then #86 — External Secrets 0.x → 0.20.4 → 2.0.1 (two-step sequence)
+
+onedr0p jumped from chart 1.3.2 to 2.0.0. Your starting point is further back,
+so this sequence adds a checkpoint on 0.20.4 to validate CRD handling before
+the major version jump.
+
+#### Step 1: #24 — External Secrets → 0.20.4
+- **Risk**: Medium
+- **Rating rationale**: This step crosses two important boundaries:
+  1. **v1beta1→v1 API migration** (happened ~0.16-0.17): Your ExternalSecrets
+     already use `apiVersion: external-secrets.io/v1` (confirmed), so this
+     should be transparent. But the CRDs at 0.16+ start serving the v1 API and
+     deprecating v1beta1 — this exercises that path.
+  2. **CRD size explosion** (~0.19+): CRDs grew past 256KB due to new
+     generators and providers. This is where Flux/Helm may fail if not using
+     server-side apply. Better to hit this issue on 0.20 (where you can debug
+     it) than on the 2.0 jump.
+
+  Good news: your ExternalSecrets already use `apiVersion: external-secrets.io/v1`
+  (confirmed in `cert-manager/cert-manager/app/externalsecret.yaml`), so the
+  API migration itself is a non-event.
+
+- **onedr0p**: Was already past 0.x when he started his 1.x→2.0 sequence. No
+  direct comparison for this step.
+
+- **Extra steps**:
+  1. **Verify your current chart version**:
+     ```bash
+     grep -A5 "external-secrets" kubernetes/apps/external-secrets/ \
+       -r --include="*.yaml" | grep -i "version\|tag"
+     ```
+  2. **Check CRD size handling**: Ensure your HelmRelease or Kustomization
+     supports large CRDs:
+     ```yaml
+     spec:
+       install:
+         crds: CreateReplace
+       upgrade:
+         crds: CreateReplace
+     ```
+     If CRDs fail to apply, you may need to enable server-side apply in Flux
+     or apply CRDs manually with `kubectl apply --server-side`.
+  3. Merge PR #24.
+  4. **Verify all ExternalSecrets are syncing**:
+     ```bash
+     kubectl get externalsecrets --all-namespaces \
+       -o custom-columns=NS:.metadata.namespace,NAME:.metadata.name,STATUS:.status.conditions[0].reason
+     ```
+  5. **Verify bitwarden-sdk-server**:
+     ```bash
+     kubectl get pods -n external-secrets | grep bitwarden
+     kubectl logs -n external-secrets <bitwarden-sdk-server-pod>
+     ```
+  6. **Wait at least 24 hours** to confirm all secrets are refreshing on
+     schedule before proceeding to Step 2.
+
+#### Step 2: #86 — External Secrets 0.20.4 → 2.0.1
+- **Risk**: Medium (from a stable 0.20 baseline)
+- **Rating rationale**: With 0.20.4 stable and CRD handling validated, the jump
+  to 2.0.1 is primarily a chart version bump. The actual v2.0.0 breaking
+  changes are minimal — only removed Alibaba and Device42 providers (which you
+  don't use). The major version number reflects the project's graduation to
+  stable, not a rewrite.
+
+- **onedr0p**: Jumped from chart 1.3.2 to 2.0.0 (#10463, Feb 6). Merged
+  cleanly, touching only `bootstrap/helmfile.d/01-apps.yaml` and the
+  OCIRepository.
+
+- **Extra steps**:
+  1. **Update bootstrap if needed**: Check if `bootstrap/helmfile.d/01-apps.yaml`
+     references external-secrets and needs a version bump.
+  2. Merge PR #86.
+  3. Verify same checklist as Step 1 (ExternalSecrets syncing, bitwarden pods).
+  4. Clean up: PR #24 is now merged and irrelevant.

--- a/upgrade-triage/05-batch-critical-infrastructure.md
+++ b/upgrade-triage/05-batch-critical-infrastructure.md
@@ -1,0 +1,166 @@
+# Batch 5: Critical Infrastructure — Maintenance Windows Required
+
+These PRs affect the cluster's CNI, storage layer, and operating system. Each
+requires a maintenance window, sequential multi-step upgrades, or is blocked
+pending upstream fixes. Do not batch these together — upgrade one subsystem at
+a time with stability verification between each.
+
+## PRs in this batch (4, covering 5 PRs)
+
+---
+
+### #47 + #48 — Rook Ceph v1.17.7 → v1.19.2 (operator + cluster)
+- **Risk**: HIGH
+- **Rating rationale**: Rook does not support skipping minor versions. You must
+  go v1.17 → v1.18 → v1.19. Additionally, Rook v1.19 drops support for Ceph
+  Reef (v18.x) — you must be running Ceph Squid (v19.2.0+) before upgrading to
+  Rook 1.19. The v1.18 release introduced mandatory CSI operator migration.
+
+- **onedr0p**: Was already on Rook 1.18.8 when he upgraded to 1.19.0 (#10392,
+  Jan 20). He also did a major Ceph infrastructure rework (#10530, Feb 18):
+  removed Thunderbolt ring networking, switched to pod networking, changed RBD
+  compression to passive, modified storage class parameters. This suggests the
+  1.18→1.19 path involved more than just a version bump for his environment.
+
+- **Extra steps — Phase 1 (v1.17 → v1.18)**:
+  1. Create a new Renovate PR or manual branch targeting Rook v1.18.x (latest
+     patch in the 1.18 line).
+  2. Read the [Rook v1.18 upgrade guide](https://rook.io/docs/rook/v1.18/Upgrade/rook-upgrade/).
+  3. **Upgrade Ceph first** if on Reef v18.x: set the Ceph image to Squid
+     v19.2.0+ in the CephCluster CR and wait for the upgrade to complete:
+     ```bash
+     kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph status
+     kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph versions
+     ```
+  4. CSI operator migration: Rook 1.18 moves CSI to an operator model. Follow
+     the migration docs carefully.
+  5. Verify cluster health: `ceph status` should show HEALTH_OK.
+
+- **Extra steps — Phase 2 (v1.18 → v1.19)**:
+  1. Only proceed after v1.18 has been stable for at least 24-48 hours.
+  2. Verify Ceph version is Squid v19.2.0+ (Reef is dropped in Rook 1.19).
+  3. Merge PRs #47 and #48 together (operator and cluster must match).
+  4. Monitor OSD, MON, and MDS pods during rollout:
+     ```bash
+     watch kubectl -n rook-ceph get pods
+     kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph -w
+     ```
+  5. StorageClass immutability: if you need to change storage class parameters,
+     create new classes rather than modifying existing ones.
+
+- **Timeline**: Plan for 2-3 days total across both phases.
+
+---
+
+### #85 — Cilium 1.18.6 → 1.19.1
+- **Risk**: HIGH — RECOMMEND HOLD
+- **Rating rationale**: Three independent blockers:
+  1. **Open regression (cilium/cilium#44430)**: Users report SSH and external
+     host connectivity loss after upgrading to 1.19.x. No fix merged yet.
+  2. **BPF memory allocation failure (cilium/cilium#44221)**: Reported on the
+     exact source version (1.18.6→1.19.0).
+  3. **CRD migration required**: `CiliumLoadBalancerIPPool` API must change from
+     `cilium.io/v2alpha1` to `cilium.io/v2`. Your `networks.yaml` likely needs
+     updating.
+
+- **onedr0p**: Merged 1.19.0 (#10451, Feb 4) but **tried to revert at 3am**
+  (#10459, Feb 6) back to 1.18.5. The revert diff is massive — shows dozens of
+  ConfigMap key removals/additions, health port naming changes, RBAC changes,
+  and image swaps. He then reverted the revert (#10461, Feb 6 12pm), deciding to
+  push forward. He also did prep work switching to the official OCI chart
+  repository (#10339) before the upgrade. Eventually stabilized on 1.19.1
+  (#10528, Feb 17) — but this was a 2-week turbulent process.
+
+- **Recommendation**: Wait for Cilium 1.19.2+ which should fix the host
+  connectivity regression. Monitor the GitHub issue for resolution.
+
+- **When you do upgrade — extra steps**:
+  1. Switch to the official Cilium OCI repository (not a mirror) first, as
+     onedr0p did.
+  2. Update CRDs:
+     ```bash
+     grep -r "cilium.io/v2alpha1" kubernetes/ --include="*.yaml"
+     ```
+     Change `CiliumLoadBalancerIPPool` from `v2alpha1` to `v2`.
+  3. Review your Cilium ConfigMap values against 1.19 defaults. Key changes:
+     - `bpf.tproxy: true` is new
+     - `policy-deny-response` removed
+     - `enable-tunnel-big-tcp` removed
+     - Health probe ports changed from named (`health`) to numeric (`9879`)
+  4. **Have out-of-band console access ready** (IPMI/iLO/Talos console). If the
+     CNI breaks, you lose SSH access to nodes.
+  5. Upgrade during a maintenance window. Monitor connectivity:
+     ```bash
+     # From outside the cluster
+     ping <node-ip>
+     ssh <node-ip>
+     # From inside the cluster
+     kubectl exec -it <test-pod> -- curl -s https://kubernetes.default
+     ```
+
+---
+
+### #11 + #21 — Talos v1.12.4 + Kubelet v1.35.1
+- **Risk**: CRITICAL — Multi-step, coupled upgrades
+- **Rating rationale**: Talos Linux is the node operating system. The installer
+  PR (#11) upgrades the Talos image, and the kubelet PR (#21) upgrades
+  Kubernetes. These are tightly coupled — Talos v1.12.4 bundles k8s 1.35.0.
+
+  **You cannot skip Talos minor versions.** If you're on v1.10, you must go
+  v1.10 → v1.11 → v1.12. Kubernetes also cannot skip minor versions — if you're
+  on 1.33, you need 1.33 → 1.34 → 1.35.
+
+  Kubernetes 1.35 removes cgroup v1 support entirely. Talos v1.12 jumps the
+  kernel from 6.12 to 6.18 and deprecates the legacy network config format in
+  favor of a new multi-document format.
+
+- **onedr0p**: Was already on Talos v1.12.0. Upgraded to v1.12.1 (#10300, Jan 5)
+  but **reverted** (#10324, Jan 8), then re-merged (#10325, Jan 9). The revert
+  suggests even minor Talos patches can cause issues. Eventually reached v1.12.4
+  (#10467, Feb 17) via incremental patches. For kubelet v1.35.1, merged as part
+  of the Talos group (#10477, Feb 17).
+
+- **Extra steps**:
+  1. **Determine your current Talos version**:
+     ```bash
+     talosctl version --nodes <node-ip>
+     ```
+  2. **If on v1.10 or v1.11 — create intermediate upgrade PRs**:
+     - v1.10 → v1.11.x (latest patch)
+     - v1.11 → v1.12.x (latest patch)
+     Each step requires:
+     ```bash
+     talosctl upgrade --nodes <node-ip> \
+       --image ghcr.io/siderolabs/installer:v1.XX.X
+     ```
+     Upgrade one node at a time. Wait for it to rejoin the cluster.
+  3. **Verify cgroup v2**: Kubernetes 1.35 drops cgroup v1. Talos uses cgroup v2
+     by default, but verify:
+     ```bash
+     talosctl read /proc/filesystems --nodes <node-ip> | grep cgroup
+     ```
+  4. **Review Talos v1.12 network config changes**: If you use the legacy single-
+     document machine config, it still works but is deprecated. The new format
+     uses multi-document YAML.
+  5. **Kubernetes version steps**: If jumping multiple k8s minors:
+     - Upgrade Talos first (which bundles the target kubelet)
+     - The kubelet version is determined by the Talos image, not a separate PR
+     - PR #21 updates the kubelet image reference in Talos machine config
+  6. **Maintenance window**: Schedule 2-4 hours. Upgrade nodes one at a time.
+     Have Talos console access available (not just SSH, which goes through the
+     CNI). Monitor:
+     ```bash
+     talosctl health --nodes <node-ip>
+     kubectl get nodes -w
+     ```
+
+---
+
+## Recommended order within this batch
+
+1. **Rook Ceph** (v1.17 → v1.18 → v1.19) — 2-3 day process
+2. **Talos + Kubelet** (version stepping as needed) — 2-4 hour maintenance window
+3. **Cilium** — HOLD until 1.19.2+. Do this last, after Talos/k8s are stable.
+
+Do NOT upgrade Cilium and Talos in the same maintenance window. If the CNI
+breaks during a Talos upgrade, diagnosis becomes extremely difficult.


### PR DESCRIPTION
## Summary

Risk assessment and batched upgrade plan for all 41 open dependency PRs. Each PR was researched for documented breaking changes, user-reported issues, and cross-referenced against [onedr0p/home-ops](https://github.com/onedr0p/home-ops) merge history to identify real-world upgrade problems.

### Batches

| Batch | PRs | Risk | Description |
|-------|-----|------|-------------|
| [0 — Close](upgrade-triage/00-superseded-close.md) | 5 | N/A | Superseded PRs to close (3 rescued as intermediate steps) |
| [1 — Immediate](upgrade-triage/01-batch-immediate.md) | 15 | Low | Patches, cosmetic majors, safe minors — no prep needed |
| [2 — Light prep](upgrade-triage/02-batch-light-prep.md) | 7 | Low-Med | Minor config tweaks or verification before merge |
| [3 — Moderate prep](upgrade-triage/03-batch-moderate-prep.md) | 5 | Med-High | Config changes, plugin replacement, testing (includes Grafana 9→10 sequence) |
| [4 — Heavy prep](upgrade-triage/04-batch-heavy-prep.md) | 4 | Med-High | CRD/bootstrap updates, sequenced upgrades (kps 73→81→82, external-secrets 0.x→0.20→2.0) |
| [5 — Critical](upgrade-triage/05-batch-critical-infrastructure.md) | 4 | High/Critical | Maintenance window required (Rook Ceph stepped, Cilium HOLD, Talos+kubelet) |

### Key findings from onedr0p cross-reference

- **Cilium 1.19**: He tried to revert at 3am after merging. Open host connectivity regression. **Recommend HOLD until 1.19.2+**
- **kube-prometheus-stack**: He never skipped a major version (went 80→81→82). We're at 73 — sequenced path through 81.6.9 added
- **External Secrets v2**: His jump was from chart 1.3.2→2.0.0. Ours is from 0.x — intermediate step through 0.20.4 added
- **Rook Ceph 1.19**: He was already on 1.18 first. We must step through 1.18 (not covered by current PRs)
- **Talos v1.12**: Even his .1 patch caused a revert. Version stepping mandatory
- **Snapshot Controller 5.0 / Envoy Gateway 1.7**: Both merged cleanly for him — risk lowered

## Test plan

- [ ] Review each batch document for accuracy against current cluster state
- [ ] Validate current versions of kps, external-secrets, Talos, and Rook match assumptions
- [ ] Begin with Batch 1 merges
- [ ] Proceed through batches sequentially with stability verification between each

🤖 Generated with [Claude Code](https://claude.com/claude-code)