### PR TITLE
docs: upgrade triage — 15 open dependency PRs

### DIFF
--- a/upgrade-triage/00-superseded-close.md
+++ b/upgrade-triage/00-superseded-close.md
@@ -1,19 +1,11 @@
-# Batch 0: Superseded PRs — Close Without Merging ✅ COMPLETE
+# Superseded PRs
 
-All 5 PRs closed on 2026-02-27.
+## Close
 
-| PR | Title | Superseded By | Status |
-|----|-------|---------------|--------|
-| #2 | Reflector 9.1.7 → 9.1.45 | #81 (→ 10.0.12) | ✅ Closed |
-| #10 | kube-prometheus-stack 73.2.2 → 73.2.3 | #79 → #89 sequence | ✅ Closed |
-| #28 | k8s-sidecar 1.30.3 → 1.30.11 | #65 (→ 2.5.0) | ✅ Closed |
-| #33 | Minecraft chart 4.26.3 → 4.26.4 | #61 (→ 5.1.1) | ✅ Closed |
-| #38 | Snapshot Controller 4.0.2 → 4.2.0 | #78 (→ 5.0.3) | ✅ Closed |
+### #116 — mariadb 11.7.2 -> 11.8.6 (superseded by #117: 11.7.2 -> 12.2.2)
 
-## Rescued as intermediate steps (moved to upgrade sequences)
+**Verdict: Close** — not a useful intermediate step.
 
-| PR | Role | Sequence | Batch | Status |
-|----|------|----------|-------|--------|
-| #9 | Grafana 9.4.5 — checkpoint before Angular-breaking 10.x | #9 → #55 | Batch 3 | ✅ Merged |
-| #79 | kube-prometheus-stack 81.6.9 — bootstrap CRD bump | #79 → #89 | Batch 4 | ✅ Closed (superseded by #89) |
-| #24 | External Secrets 0.20.4 — stabilize on latest 0.x before 2.0 jump | #24 → #86 | Batch 4 | ✅ Merged |
+MariaDB 11.8 is within the same major version as 11.7 and is not a documented upgrade boundary for the 11-to-12 migration. MariaDB officially supports direct upgrades from any earlier version to the latest, so stepping through 11.8 provides no meaningful risk reduction. The rolling release model in 12.x means 11.8 will itself go EOL quickly.
+
+If you prefer extra caution, you could merge #116 first as a low-risk warm-up, but it is not required and adds unnecessary churn.

--- a/upgrade-triage/01-batch-immediate.md
+++ b/upgrade-triage/01-batch-immediate.md
@@ -1,33 +1,48 @@
-# Batch 1: Immediate Merges — No Prep Required ✅ COMPLETE
+# Batch 1 — Immediate (no prep needed)
 
-All 15 PRs merged on 2026-02-27 in three groups.
+Merge these directly. All are patches or low-risk minors with no breaking changes.
 
-## Group A — CI only (merged simultaneously)
+---
 
-| PR | Title | Status |
-|----|-------|--------|
-| #71 | actions/checkout v4.3.1 → v6.0.2 | ✅ Merged |
-| #68 | flux-local v7.11.0 → v8.1.0 | ✅ Merged |
-| #53 | tj-actions/changed-files v46.0.5 → v47.0.4 | ✅ Merged (SHA verified) |
+## #110 — kube-prometheus-stack 82.4.1 -> 82.4.3
 
-## Group B — Negligible patches (merged together)
+- **Risk:** Negligible
+- **Rationale:** Patch bump within the 82.x line. No config changes.
+- **Reference repo:** onedr0p merged all 82.x patches without issue, auto-merging aggressively through the entire 82.0.0-82.4.3 range with zero reverts.
+- **Extra steps:** None.
 
-| PR | Title | Status |
-|----|-------|--------|
-| #87 | Reloader 2.2.7 → 2.2.8 | ✅ Merged |
-| #83 | mc-router 1.4.0 → 1.4.1 | ✅ Merged |
-| #64 | Promtail 6.17.0 → 6.17.1 | ✅ Merged |
-| #54 | tnu 0.4.3 → 0.4.4 | ✅ Merged |
-| #82 | Cloudflared tool (mise) 2025.11.1 → 2026.2.0 | ✅ Merged |
+---
 
-## Group C — Low-risk minors (merged together)
+## #109 — reflector 10.0.13 -> 10.0.14
 
-| PR | Title | Notes | Status |
-|----|-------|-------|--------|
-| #74 | cert-manager v1.19.2 → v1.19.4 | | ✅ Merged |
-| #80 | Cloudflared container 2026.1.2 → 2026.2.0 | | ✅ Merged |
-| #81 | Reflector 9.1.7 → 10.0.12 | Cosmetic major | ✅ Merged |
-| #88 | Flux Operator 0.40.0 → 0.42.1 | Anon auth CRB not needed (web UI not exposed) | ✅ Merged |
-| #13 | app-template 4.0.1 → 4.6.2 | | ✅ Merged |
-| #29 | System Upgrade Controller v0.15.2 → v0.19.0 | | ✅ Merged |
-| #39 | Gatus v5.18.1 → v5.35.0 | | ✅ Merged |
+- **Risk:** Negligible
+- **Rationale:** Patch bump. Reflector is a simple secret/configmap mirror.
+- **Reference repo:** No comparison available (removed from their cluster years ago).
+- **Extra steps:** None.
+
+---
+
+## #108 — booklore v2.0.2 -> v2.0.5
+
+- **Risk:** Negligible
+- **Rationale:** Patch bump within the 2.0.x line.
+- **Reference repo:** No comparison available (not used).
+- **Extra steps:** None.
+
+---
+
+## #114 — prowlarr-develop 1.31.2.4975 -> 1.32.2.4987
+
+- **Risk:** Low
+- **Rationale:** Minor bump. Prowlarr develop builds are frequent and generally stable. No breaking changes expected within the 1.x line.
+- **Reference repo:** onedr0p uses a different image (`ghcr.io/home-operations/prowlarr`) and is already on 2.x. No direct comparison, but their 1.x-to-2.x jump had zero reverts.
+- **Extra steps:** None.
+
+---
+
+## #113 — shelfmark v1.0.2 -> v1.1.2
+
+- **Risk:** Low
+- **Rationale:** Minor bump. Shelfmark is a relatively simple app.
+- **Reference repo:** No comparison available (not used).
+- **Extra steps:** None.

--- a/upgrade-triage/02-batch-light-prep.md
+++ b/upgrade-triage/02-batch-light-prep.md
@@ -1,18 +1,57 @@
-# Batch 2: Light Prep — Minor Config or Verification Before Merge ✅ COMPLETE
+# Batch 2 — Light Prep (minor config or verification)
 
-All 7 PRs resolved on 2026-02-27.
+These need a small action before or after merge, but are straightforward.
 
-| PR | Title | Prep Done | Status |
-|----|-------|-----------|--------|
-| #51 | actions/labeler v5.0.0 → v6.0.1 | Verified no dotfile matching issues | ✅ Merged |
-| #106 | NFS mount scoping and shelfmark permissions | Deferred — Shelfmark blocked on Deluge VPN | ✅ Closed |
-| #78 | Snapshot Controller 4.0.2 → 5.0.3 | CRDs already Helm-managed with CreateReplace | ✅ Merged |
-| #84 | Envoy Gateway v1.6.3 → v1.7.0 | No deprecated buffer/timeout settings found | ✅ Merged |
-| #90 | SM-Operator 0.1.0 → 2.0.0 | Updated semver constraint to `<3.0.0` | ✅ Closed (applied manually) |
-| #37 | VolSync 0.12.1 → 0.14.0 | `disableAuth: true` already set | ✅ Merged |
-| #14 | OpenEBS 4.2.0 → 4.4.0 | Added `loki.enabled: false` and `alloy.enabled: false` | ✅ Merged |
+---
 
-## Prep commits
+## #5 — kube-rbac-proxy v0.14.1 -> v0.16.0 [URGENT]
 
-- `9e43294` — SM-Operator semver constraint and OpenEBS loki/alloy disable
-- `b516696` — SM-Operator constraint aligned with Renovate (`<3.0.0`)
+- **Risk:** Low (version bump itself) / **High urgency** (dead registry)
+- **Rationale:** The version bump is minor and safe. The **real urgency** is that `gcr.io/kubebuilder/kube-rbac-proxy` is dead — GCR stopped serving this image after March 2025. Your pods only work because the image is cached on nodes. Any node replacement, drain, or image eviction will cause a pull failure and the bitwarden-sm operator will not start.
+- **Reference repo:** No comparison available (not used standalone).
+- **Extra steps:**
+  1. Change the image registry in `kubernetes/apps/bitwarden-sm/bitwarden-sm/app/helm/values.yaml`:
+     ```yaml
+     # FROM:
+     gcr.io/kubebuilder/kube-rbac-proxy:v0.14.1
+     # TO:
+     quay.io/brancz/kube-rbac-proxy:v0.16.0
+     ```
+  2. Verify bitwarden-sm pods restart successfully:
+     ```
+     kubectl rollout status deployment -n bitwarden-sm -l app.kubernetes.io/name=bitwarden-sm
+     ```
+
+---
+
+## #111 — flux-operator 0.42.1 -> 0.43.0
+
+- **Risk:** Low
+- **Rationale:** Minor version bump of the flux-operator. Follows semver, no breaking API changes expected. Controls the entire Flux installation, so verify before applying.
+- **Reference repo:** onedr0p merged 0.42.1 -> 0.43.0 on 2026-02-27 with no reverts. **However**, the preceding 0.42.1 upgrade required an immediate companion commit to "add anon auth to flux operator." Check if your FluxInstance config needs a similar change.
+- **Extra steps:**
+  1. Check if your FluxInstance needs an `anonAuth` configuration. Review onedr0p's chore commit for details:
+     ```
+     gh pr view 10561 --repo onedr0p/home-ops --json body,files
+     ```
+  2. After merge, verify Flux is healthy:
+     ```
+     flux check
+     kubectl get fluxinstance -A
+     ```
+
+---
+
+## #112 — audiobookshelf 2.19.5 -> 2.32.1
+
+- **Risk:** Low-Medium
+- **Rationale:** Large minor version jump (13 minors). The major change is a **new JWT authentication system in v2.26.0** — all users must re-login after upgrade. Mobile app clients also need re-authentication. Database migrations run automatically on startup.
+- **Reference repo:** No comparison available (removed from their cluster in 2023).
+- **Extra steps:**
+  1. Snapshot the config PVC before upgrading (trigger a VolSync snapshot or manual backup).
+  2. **Notify all users** they will need to re-login (web and mobile apps) after the upgrade.
+  3. After merge, verify the pod starts and database migrations complete:
+     ```
+     kubectl logs -n media -l app.kubernetes.io/name=audiobookshelf --tail=50
+     ```
+  4. Confirm the web UI loads and login works at `audiobookshelf.${SECRET_DOMAIN}`.

--- a/upgrade-triage/04-batch-heavy-prep.md
+++ b/upgrade-triage/04-batch-heavy-prep.md
@@ -1,31 +1,3 @@
-# Batch 4: Heavy Prep — CRD Updates, Bootstrap Changes, Coordinated Upgrades ✅ COMPLETE
+# Batch 4 — Heavy Prep (CRD/bootstrap changes, coordinated upgrades)
 
-All 4 PRs resolved on 2026-02-27.
-
-## kube-prometheus-stack 73.2.2 → 82.4.1
-
-The original plan called for a two-step sequence (#79 → #89), but #79 only bumped
-bootstrap CRDs (not the cluster). Since bootstrap CRDs were already at 81.4.2 and
-the HelmRelease has `crds.upgradeJob.enabled: true` with `forceConflicts: true`,
-the intermediate step added no safety. Went directly to 82.4.1.
-
-| PR | Title | Status |
-|----|-------|--------|
-| #79 | kps bootstrap CRDs 81.4.2 → 81.6.9 | ✅ Closed (superseded by #89) |
-| #89 | kps 73.2.2 → 82.4.1 (bootstrap + cluster) | ✅ Merged |
-
-Verified: Prometheus targets scraping, Alertmanager receiving alerts, Grafana
-dashboards rendering, custom PrometheusRules (dockerhub, oom, zfs) intact.
-
-## External Secrets 0.17.0 → 2.0.1 (two-step sequence)
-
-Executed as planned. CRD size handling validated on the 0.20.4 step (no issues).
-
-| PR | Title | Status |
-|----|-------|--------|
-| #24 | External Secrets 0.17.0 → 0.20.4 (bootstrap + cluster) | ✅ Merged |
-| #86 | External Secrets 0.20.4 → 2.0.1 (bootstrap + cluster) | ✅ Merged |
-
-Verified after each step: ExternalSecrets syncing, bitwarden-sdk-server running,
-forced secret sync successful. Bootstrap and cluster versions kept in sync
-throughout.
+No PRs currently fall into this batch. The Talos/kubelet multi-step upgrades are in Batch 5 (critical infrastructure) due to their OS/kernel-level impact.

--- a/upgrade-triage/05-batch-critical-infrastructure.md
+++ b/upgrade-triage/05-batch-critical-infrastructure.md
@@ -1,93 +1,88 @@
-# Batch 5: Critical Infrastructure — Maintenance Windows Required
+# Batch 5 — Critical Infrastructure (maintenance window)
 
-These PRs affect the cluster's CNI, storage layer, and operating system. Each
-requires a maintenance window, sequential multi-step upgrades, or is blocked
-pending upstream fixes. Do not batch these together — upgrade one subsystem at
-a time with stability verification between each.
+These affect CNI, OS/kernel, or Kubernetes version. Require a maintenance window, careful sequencing, and rollback plans.
 
 ---
 
-## Rook Ceph (#47 + #48) — v1.17.7 → v1.19.2 ✅ COMPLETE
+## #85 — Cilium 1.18.6 -> 1.19.1 (CNI)
 
-**Phase 1 (v1.17.7 → v1.18.9): ✅ COMPLETE** — deployed 2026-02-27.
-- Ceph confirmed on Squid v19.2.3 (satisfies v1.19 prerequisite).
-- Manual commit `36fa4a8` bumped both OCIRepositories to v1.18.9.
-- OSDs rolled successfully, cluster reporting HEALTH_OK.
-
-**Phase 2 (v1.18.9 → v1.19.2): ✅ COMPLETE** — deployed 2026-02-27.
-- Soaked on v1.18.9 for 12+ hours before proceeding.
-- Renovate rebased PRs #47 and #48 against v1.18.9, so both merged cleanly.
-- MGR pods crashed during rollout (expected during minor upgrade), recovered.
-- Cluster stable at v1.19.2.
-
----
-
-## Cilium (#85) — v1.18.6 → v1.19.1 ⛔ ON HOLD
-
-**Status**: Blocked on upstream regressions. Do not upgrade.
-
-Three independent blockers:
-1. **Open regression (cilium/cilium#44430)**: SSH and external host connectivity
-   loss after upgrading to 1.19.x. No fix merged yet.
-2. **BPF memory allocation failure (cilium/cilium#44221)**: Reported on the exact
-   source version (1.18.6→1.19.0).
-3. **CRD migration required**: `CiliumLoadBalancerIPPool` API must change from
-   `cilium.io/v2alpha1` to `cilium.io/v2`.
-
-**onedr0p experience**: Merged 1.19.0 but attempted 3am revert. 2-week turbulent
-stabilization process.
-
-**Action**: Wait for Cilium 1.19.2+ with host connectivity fix. Monitor
-cilium/cilium#44430 for resolution.
-
-**When upgrading — prep checklist**:
-1. Switch to official Cilium OCI repository
-2. Update `CiliumLoadBalancerIPPool` from `v2alpha1` to `v2`
-3. Review ConfigMap values against 1.19 defaults
-4. Have out-of-band console access ready (IPMI/Talos console, not SSH)
-5. Schedule maintenance window
+- **Risk:** Medium-High
+- **Rationale:** Cilium is the CNI — a failed upgrade means cluster-wide networking loss. Cilium 1.19 has a `CiliumLoadBalancerIPPool` API version change (`v2alpha1` -> `v2`) that directly affects your config. Removed flags don't impact your values, and you don't use Cilium's Gateway API (separate Envoy Gateway). However, a user-reported regression ([cilium#44221](https://github.com/cilium/cilium/issues/44221)) describes complete networking failure on 1.18->1.19 upgrade.
+- **Reference repo:** onedr0p merged Cilium 1.19.0 on 2026-02-04, **reverted it 2 days later**, then **re-reverted (re-applied) 9 hours after that**. They are now stable on 1.19.1. The revert suggests initial instability but ultimate success. They also migrated the chart source from a mirror to the official Cilium OCI repo beforehand.
+- **Extra steps:**
+  1. **Update `CiliumLoadBalancerIPPool` apiVersion** before or during the upgrade:
+     ```yaml
+     # In kubernetes/apps/kube-system/cilium/app/networks.yaml
+     # Change: apiVersion: cilium.io/v2alpha1
+     # To:     apiVersion: cilium.io/v2
+     ```
+  2. Update the Cilium chart version in both:
+     - `kubernetes/apps/kube-system/cilium/app/ocirepository.yaml`
+     - `bootstrap/helmfile.d/01-apps.yaml`
+  3. After merge, monitor pod connectivity across all namespaces:
+     ```
+     cilium status
+     cilium connectivity test
+     kubectl get pods -A | grep -v Running
+     ```
+  4. **Have a rollback plan ready.** If networking breaks, revert the chart version and CRD changes immediately.
+  5. **Do NOT upgrade simultaneously with Talos 1.12.** The eBPF verifier regression on kernel 6.18.x ([siderolabs/talos#12726](https://github.com/siderolabs/talos/issues/12726)) compounds with Cilium changes. Upgrade Cilium first on the current Talos/kernel, validate, then upgrade Talos separately.
 
 ---
 
-## Talos (#11) + Kubelet (#21) — v1.12.4 + k8s v1.35.2 ✅ COMPLETE
+## #118 + #119 — Talos v1.10.4 -> v1.12.4 + Kubelet v1.33.2 -> v1.35.2 (OS + Kubernetes)
 
-### Steps 1-2: ✅ COMPLETE — deployed 2026-02-27
+These are tightly coupled and must be sequenced together.
 
-- Talos upgraded v1.10.4 → v1.11.6 (all 7 nodes)
-- Kubernetes upgraded v1.33.2 → v1.34.4 (siderolabs kubelet latest for 1.34)
-- Fixed: added `admissionregistration.k8s.io/v1beta1=true` to API server
-  runtime-config — `MutatingAdmissionPolicy` graduated from v1alpha1 to v1beta1
-  in k8s 1.34, causing apiserver crash loops without this.
+- **Risk:** High
+- **Rationale:** Two minor OS versions and two minor Kubernetes versions across 7 nodes. Sequential upgrade is **mandatory** for both Talos (1.10->1.11->1.12) and Kubernetes (1.33->1.34->1.35). Talos 1.12 ships kernel 6.18.x which has a known eBPF verifier regression affecting Cilium ([siderolabs/talos#12726](https://github.com/siderolabs/talos/issues/12726)). The `.machine.network` config format is deprecated in 1.12 but still functional.
+- **Reference repo:** onedr0p upgraded incrementally through every version. Talos updates triggered multiple reverts due to factory image availability timing (merged, reverted same day, re-applied next day). Kubelet upgrades were smooth with zero reverts. They also removed a Talos feature gate (`ResourceHealthStatus`) as a chore commit during the 1.11 cycle.
 
-### Steps 3-4: ✅ COMPLETE — deployed 2026-02-27
+### Upgrade Sequence
 
-- Talos upgraded v1.11.6 → v1.12.4 (all 7 nodes, `--reboot-mode=powercycle`)
-- Kubernetes upgraded v1.34.4 → v1.35.2
-- Dropped `admissionregistration.k8s.io/v1alpha1=true` from runtime-config
-  (v1alpha1 no longer served in k8s 1.35).
-- Migrated VolSync MutatingAdmissionPolicy manifests from v1alpha1 to v1beta1.
-- Converted admission-controller patch from JSON6902 to strategic merge
-  (`$$patch: delete` for talhelper escaping) — Talos v1.12 dropped JSON6902
-  support for multi-document configs.
-- OSD.1 went down after upgrade due to PodSecurity `baseline:latest` enforcement
-  blocking Rook pods. Resolved by applying updated admission control config to
-  CP nodes; OSD purged and rebuilt, Ceph back to HEALTH_OK with 5/5 OSDs.
-- PRs #11 and #21 closed (versions applied manually via stepping).
+**Step 1: Talos 1.10.4 -> 1.11.x + Kubernetes 1.33 -> 1.34**
 
-**Key lessons:**
-- Use `task talos:upgrade-node` and `task talos:upgrade-k8s` (not raw talosctl)
-- Regenerate configs before upgrading k8s (version baked into machine configs)
-- Check API server feature gate / runtime-config compatibility at each k8s minor
-- Siderolabs kubelet images lag slightly behind upstream k8s releases
-- Talos v1.12 requires strategic merge patches — use `$$patch:` to escape for talhelper
-- Use `--reboot-mode=powercycle` to avoid kexec hang on v1.12
+1. Update Talos installer image to latest 1.11.x in talconfig.
+2. Regenerate machine configs with `talhelper`.
+3. Upgrade control plane nodes one at a time:
+   ```
+   talosctl upgrade --nodes <cp-node> --image factory.talos.dev/installer/...:v1.11.x
+   ```
+4. Upgrade worker nodes one at a time.
+5. After all nodes are on Talos 1.11, upgrade Kubernetes:
+   ```
+   talosctl upgrade-k8s --to 1.34.x
+   ```
+6. Validate cluster health. Run workloads for at least 24-48 hours before proceeding.
+
+**Step 2: Talos 1.11.x -> 1.12.4 + Kubernetes 1.34 -> 1.35.2**
+
+1. **CRITICAL:** Verify Cilium stability on the current version first. The kernel 6.18.x eBPF verifier bug may cause node instability and networking loss.
+2. Check [siderolabs/talos#12726](https://github.com/siderolabs/talos/issues/12726) for resolution status. **If still open, HOLD this step.**
+3. If proceeding, same node-by-node upgrade process as Step 1.
+4. After all nodes on 1.12, upgrade Kubernetes:
+   ```
+   talosctl upgrade-k8s --to 1.35.2
+   ```
+5. Monitor for eBPF verifier errors:
+   ```
+   talosctl dmesg --nodes <node> | grep -i "bpf\|verifier\|INVARIANTS"
+   ```
+
+### Post-upgrade
+
+- No machine config format migration is required (legacy format continues to work in 1.12).
+- Plan eventual migration from `.machine.network` to `NetworkConfig` documents at a later date.
 
 ---
 
-## Recommended order
+## #115 — Gluetun v3.39.1 -> v3.41.1 [HOLD]
 
-1. **Rook Ceph** — ✅ COMPLETE (v1.17.7 → v1.18.9 → v1.19.2)
-2. **Talos + Kubelet** — ✅ COMPLETE (v1.10.4/v1.33.2 → v1.12.4/v1.35.2)
-3. **Cilium** — HOLD until 1.19.2+, do last after Talos/k8s stable
-
-Do NOT upgrade Cilium and Talos in the same maintenance window.
+- **Risk:** High
+- **Rationale:** **Do not upgrade.** Gluetun v3.41 **removed the `HEALTH_VPN_DURATION_INITIAL` env var** which your config relies on (`HEALTH_VPN_DURATION_INITIAL: "15s"`) to give WireGuard time to establish before health checks begin. Without it, the hardcoded 6-second timeout causes the exact startup health check cycling that prompted the v3.39.1 pin. Additionally, v3.40 replaced Unbound with a custom Go DNS resolver that has known issues in Kubernetes environments, and the control server API now requires authentication on all routes.
+- **Reference repo:** No comparison available (onedr0p removed VPN networking entirely).
+- **HOLD condition:** Do not upgrade until upstream gluetun provides a replacement mechanism for configuring the VPN startup health check timeout. Track:
+  - [qdm12/gluetun#2942](https://github.com/qdm12/gluetun/issues/2942) — health check restarting VPN
+  - [qdm12/gluetun#3069](https://github.com/qdm12/gluetun/issues/3069) — health check failures
+  - [qdm12/gluetun#3134](https://github.com/qdm12/gluetun/issues/3134) — ongoing health check issues
+- **Extra steps:** None. Keep pinned at v3.39.1.


### PR DESCRIPTION
## Summary

Assessed all 15 open Renovate PRs, researched upgrade risks, and cross-referenced against [onedr0p/home-ops](https://github.com/onedr0p/home-ops) merge history.

| Batch | PRs | Description |
|-------|-----|-------------|
| [Superseded](upgrade-triage/00-superseded-close.md) | #116 | Close — mariadb 11.8 not needed as intermediate step |
| [1 — Immediate](upgrade-triage/01-batch-immediate.md) | #110, #109, #108, #114, #113 | Patches and safe minors, merge directly |
| [2 — Light prep](upgrade-triage/02-batch-light-prep.md) | #5, #111, #112 | Small config tweaks or verification needed |
| [3 — Moderate prep](upgrade-triage/03-batch-moderate-prep.md) | #117, #69 | Major versions needing backup/testing |
| [4 — Heavy prep](upgrade-triage/04-batch-heavy-prep.md) | — | Empty (multi-step upgrades in Batch 5) |
| [5 — Critical infra](upgrade-triage/05-batch-critical-infrastructure.md) | #85, #118, #119, #115 | CNI, OS, k8s — maintenance window required |

## Key Findings from Cross-Reference

- **kube-rbac-proxy (#5)** — `gcr.io` registry is dead. Pods survive on node cache only. Urgent registry swap needed.
- **Gluetun (#115)** — HOLD. v3.41 removed `HEALTH_VPN_DURATION_INITIAL` which is critical to your setup. Keep pinned at v3.39.1.
- **Cilium (#85)** — onedr0p reverted 1.19.0 then re-applied it within hours. Ultimately stable on 1.19.1. Needs `CiliumLoadBalancerIPPool` apiVersion update.
- **Helm 4 (#69)** — onedr0p has closed 6 consecutive Helm 4 PRs since Nov 2025. Strong signal to defer.
- **Talos (#118) + kubelet (#119)** — Sequential upgrade mandatory (1.10->1.11->1.12). Talos 1.12 kernel 6.18.x has eBPF verifier regression affecting Cilium. Do NOT upgrade Talos and Cilium together.
- **Flux-operator (#111)** — onedr0p needed a companion "anon auth" config change with 0.42.1. Check if yours needs the same.

## Recommended Order

1. Batch 1 (immediate patches)
2. kube-rbac-proxy registry fix (urgent)
3. Flux-operator, audiobookshelf (light prep)
4. MariaDB (with backup)
5. Cilium (maintenance window, before Talos)
6. Talos Step 1: 1.10->1.11 + k8s 1.33->1.34
7. Talos Step 2: 1.11->1.12 + k8s 1.34->1.35 (pending eBPF bug resolution)
8. Helm 4 and gluetun — defer/hold

🤖 Generated with [Claude Code](https://claude.com/claude-code)