### PR TITLE
feat(media): add recyclarr for TRaSH Guides profile sync

### DIFF
--- a/kubernetes/apps/media/kustomization.yaml
+++ b/kubernetes/apps/media/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
   - ./qbittorrent/ks.yaml
   - ./radarr/ks.yaml
   - ./radarr4k/ks.yaml
+  - ./recyclarr/ks.yaml
   - ./sabnzbd/ks.yaml
   - ./shelfmark/ks.yaml
   - ./sonarr/ks.yaml

--- a/kubernetes/apps/media/recyclarr/app/configmap.yaml
+++ b/kubernetes/apps/media/recyclarr/app/configmap.yaml
@@ -1,0 +1,93 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: recyclarr-configmap
+data:
+  recyclarr.yml: |
+    sonarr:
+      sonarr:
+        base_url: http://sonarr.media.svc.cluster.local
+        api_key: !env_var SONARR_API_KEY
+        delete_old_custom_formats: true
+
+        include:
+          - template: sonarr-quality-definition-series
+          - template: sonarr-v4-quality-profile-web-1080p
+          - template: sonarr-v4-custom-formats-web-1080p
+          - template: sonarr-quality-definition-anime
+          - template: sonarr-v4-quality-profile-anime
+          - template: sonarr-v4-custom-formats-anime
+
+        custom_formats:
+          # Anime - prefer dual audio and 10bit
+          - trash_ids:
+              - 418f50b10f1907201b6cfdf881f467b7 # Anime Dual Audio
+            assign_scores_to:
+              - name: Remux-1080p - Anime
+                score: 10
+          - trash_ids:
+              - b2550eb333d27b75833e25b8c2557b38 # 10bit
+            assign_scores_to:
+              - name: Remux-1080p - Anime
+                score: 10
+          - trash_ids:
+              - 026d5aadd1a6b4e550b134cb6c72b3ca # Uncensored
+            assign_scores_to:
+              - name: Remux-1080p - Anime
+                score: 10
+
+      sonarr4k:
+        base_url: http://sonarr4k.media.svc.cluster.local
+        api_key: !env_var SONARR4K_API_KEY
+        delete_old_custom_formats: true
+
+        include:
+          - template: sonarr-quality-definition-series
+          - template: sonarr-v4-quality-profile-web-2160p
+          - template: sonarr-v4-custom-formats-web-2160p
+
+        custom_formats:
+          # HDR Formats
+          - trash_ids:
+              - 9b27ab6498ec0f31a3353992e19434ca # DV (w/o HDR fallback)
+            assign_scores_to:
+              - name: WEB-2160p
+          # Block SDR
+          - trash_ids:
+              - 2016d1676f5ee13a5b7257ff86ac9a93 # SDR
+            assign_scores_to:
+              - name: WEB-2160p
+
+    radarr:
+      radarr:
+        base_url: http://radarr.media.svc.cluster.local
+        api_key: !env_var RADARR_API_KEY
+        delete_old_custom_formats: true
+
+        include:
+          - template: radarr-quality-definition-movie
+          - template: radarr-quality-profile-remux-web-1080p
+          - template: radarr-custom-formats-remux-web-1080p
+
+      radarr4k:
+        base_url: http://radarr4k.media.svc.cluster.local
+        api_key: !env_var RADARR4K_API_KEY
+        delete_old_custom_formats: true
+
+        include:
+          - template: radarr-quality-definition-movie
+          - template: radarr-quality-profile-remux-web-2160p
+          - template: radarr-custom-formats-remux-web-2160p
+
+        custom_formats:
+          # Block DV without HDR fallback
+          - trash_ids:
+              - 923b6abef9b17f937fab56cfcf89e1f1 # DV (w/o HDR fallback)
+            assign_scores_to:
+              - name: Remux + WEB 2160p
+          # Block SDR
+          - trash_ids:
+              - 9c38ebb7384dada637be8899efa68e6f # SDR
+            assign_scores_to:
+              - name: Remux + WEB 2160p

--- a/kubernetes/apps/media/recyclarr/app/externalsecret.yaml
+++ b/kubernetes/apps/media/recyclarr/app/externalsecret.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: recyclarr
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: bitwarden-secretsmanager
+  target:
+    name: recyclarr-secret
+    template:
+      data:
+        SONARR_API_KEY: "{{ .SONARR_API_KEY }}"
+        SONARR4K_API_KEY: "{{ .SONARR4K_API_KEY }}"
+        RADARR_API_KEY: "{{ .RADARR_API_KEY }}"
+        RADARR4K_API_KEY: "{{ .RADARR4K_API_KEY }}"
+  data:
+    - secretKey: SONARR_API_KEY
+      remoteRef:
+        key: "064f8557-01a2-4374-a5ae-b40a008bdd39"
+    - secretKey: SONARR4K_API_KEY
+      remoteRef:
+        key: "fa4b471e-6c34-46fe-9ef7-b40a008b74ef"
+    - secretKey: RADARR_API_KEY
+      remoteRef:
+        key: "287d134a-6820-471f-9c7d-b40a008b8044"
+    - secretKey: RADARR4K_API_KEY
+      remoteRef:
+        key: "875cfc05-309d-4246-a3ea-b40a008b8eaf"

--- a/kubernetes/apps/media/recyclarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/recyclarr/app/helmrelease.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: recyclarr
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 1h
+  values:
+    controllers:
+      recyclarr:
+        type: cronjob
+        cronjob:
+          schedule: "0 5 * * *"
+          backoffLimit: 0
+          concurrencyPolicy: Forbid
+          successfulJobsHistory: 1
+          failedJobsHistory: 1
+        containers:
+          app:
+            image:
+              repository: ghcr.io/recyclarr/recyclarr
+              tag: 8.4.0
+            args:
+              - sync
+            env:
+              TZ: America/Chicago
+            envFrom:
+              - secretRef:
+                  name: recyclarr-secret
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                memory: 128Mi
+        pod:
+          restartPolicy: Never
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            fsGroupChangePolicy: OnRootMismatch
+    persistence:
+      config:
+        existingClaim: recyclarr
+        globalMounts:
+          - path: /config
+      config-file:
+        type: configMap
+        name: recyclarr-configmap
+        globalMounts:
+          - path: /config/recyclarr.yml
+            subPath: recyclarr.yml
+            readOnly: true
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/media/recyclarr/app/kustomization.yaml
+++ b/kubernetes/apps/media/recyclarr/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./externalsecret.yaml
+  - ./configmap.yaml

--- a/kubernetes/apps/media/recyclarr/ks.yaml
+++ b/kubernetes/apps/media/recyclarr/ks.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app recyclarr
+  namespace: &namespace media
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/volsync
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+    - name: sonarr
+    - name: sonarr4k
+    - name: radarr
+    - name: radarr4k
+  interval: 1h
+  path: ./kubernetes/apps/media/recyclarr/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 1Gi
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false


### PR DESCRIPTION
## Summary
- Deploy recyclarr as a daily cronjob (5 AM) to sync TRaSH Guides quality profiles
- Configures sonarr (WEB-1080p + Anime), sonarr4k (WEB-2160p), radarr (Remux + WEB 1080p), radarr4k (Remux + WEB 2160p)
- HDR enforced for 4K instances (SDR and DV w/o HDR fallback blocked)
- API keys pulled from Bitwarden Secrets Manager via ExternalSecret

## Test plan
- [ ] `flux get ks recyclarr -n media` shows Ready
- [ ] `kubectl get hr recyclarr -n media` shows Ready
- [ ] Trigger a manual job run and verify logs show successful sync to all 4 instances
- [ ] Verify quality profiles appear in sonarr/radarr UIs

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)