### PR TITLE
fix(media): update NFS media path to lowercase

### DIFF
--- a/kubernetes/apps/media/audiobookshelf/app/helmrelease.yaml
+++ b/kubernetes/apps/media/audiobookshelf/app/helmrelease.yaml
@@ -88,6 +88,6 @@ spec:
       media:
         type: nfs
         server: snotra.internal
-        path: /mnt/user/Media
+        path: /mnt/user/media
         globalMounts:
           - path: /data/media

--- a/kubernetes/apps/media/booklore/app/helmrelease.yaml
+++ b/kubernetes/apps/media/booklore/app/helmrelease.yaml
@@ -80,7 +80,7 @@ spec:
       media:
         type: nfs
         server: snotra.internal
-        path: /mnt/user/Media
+        path: /mnt/user/media
         globalMounts:
           - path: /data/media
       bookdrop:

--- a/kubernetes/apps/media/qbittorrent/app/helmrelease.yaml
+++ b/kubernetes/apps/media/qbittorrent/app/helmrelease.yaml
@@ -169,7 +169,7 @@ spec:
       media:
         type: nfs
         server: snotra.internal
-        path: /mnt/user/Media
+        path: /mnt/user/media
         advancedMounts:
           qbittorrent:
             app:

--- a/kubernetes/apps/media/radarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/radarr/app/helmrelease.yaml
@@ -81,7 +81,7 @@ spec:
       media:
         type: nfs
         server: snotra.internal
-        path: /mnt/user/Media
+        path: /mnt/user/media
         globalMounts:
           - path: /data/media
       downloads:

--- a/kubernetes/apps/media/radarr4k/app/helmrelease.yaml
+++ b/kubernetes/apps/media/radarr4k/app/helmrelease.yaml
@@ -81,7 +81,7 @@ spec:
       media:
         type: nfs
         server: snotra.internal
-        path: /mnt/user/Media
+        path: /mnt/user/media
         globalMounts:
           - path: /data/media
       downloads:

--- a/kubernetes/apps/media/sabnzbd/app/helmrelease.yaml
+++ b/kubernetes/apps/media/sabnzbd/app/helmrelease.yaml
@@ -77,7 +77,7 @@ spec:
       media:
         type: nfs
         server: snotra.internal
-        path: /mnt/user/Media
+        path: /mnt/user/media
         globalMounts:
           - path: /data/media
       downloads:

--- a/kubernetes/apps/media/shelfmark/app/helmrelease.yaml
+++ b/kubernetes/apps/media/shelfmark/app/helmrelease.yaml
@@ -67,7 +67,7 @@ spec:
       media:
         type: nfs
         server: snotra.internal
-        path: /mnt/user/Media
+        path: /mnt/user/media
         globalMounts:
           - path: /data/media
       downloads:

--- a/kubernetes/apps/media/sonarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/sonarr/app/helmrelease.yaml
@@ -81,7 +81,7 @@ spec:
       media:
         type: nfs
         server: snotra.internal
-        path: /mnt/user/Media
+        path: /mnt/user/media
         globalMounts:
           - path: /data/media
       downloads:

--- a/kubernetes/apps/media/sonarr4k/app/helmrelease.yaml
+++ b/kubernetes/apps/media/sonarr4k/app/helmrelease.yaml
@@ -81,7 +81,7 @@ spec:
       media:
         type: nfs
         server: snotra.internal
-        path: /mnt/user/Media
+        path: /mnt/user/media
         globalMounts:
           - path: /data/media
       downloads:


### PR DESCRIPTION
## Summary
- Update NFS mount path from `/mnt/user/Media` to `/mnt/user/media` across all 9 media app helmreleases
- Corresponds to renaming the Unraid share from `Media` to `media`

## Prerequisites (manual, on Unraid)
Before merging this PR, rename the share and subdirectories on Unraid:
- `Media` → `media` (share name)
- `Movies` → `movies`, `TV` → `tv`, `Music` → `music`, `Standups` → `standups`
- `4K/Movies` → `movies-4k`, `4K/TV` → `tv-4k`
- Create `anime` directory

## Post-merge
- [ ] Verify all media pods remount successfully (`kubectl get pods -n media`)
- [ ] Update root folder paths in Sonarr, Sonarr4k, Radarr, Radarr4k UIs to match new lowercase subdirectory names

🤖 Generated with [Claude Code](https://claude.com/claude-code)