### PR TITLE
feat(media): add plex media server deployment

### DIFF
--- a/kubernetes/apps/media/kustomization.yaml
+++ b/kubernetes/apps/media/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - ./mariadb/ks.yaml
   - ./audiobookshelf/ks.yaml
   - ./booklore/ks.yaml
+  - ./plex/ks.yaml
   - ./prowlarr/ks.yaml
   - ./qbittorrent/ks.yaml
   - ./radarr/ks.yaml

--- a/kubernetes/apps/media/plex/app/dnsendpoint.yaml
+++ b/kubernetes/apps/media/plex/app/dnsendpoint.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: externaldns.k8s.io/v1alpha1
+kind: DNSEndpoint
+metadata:
+  name: plex
+spec:
+  endpoints:
+    - dnsName: "plex.${SECRET_DOMAIN}"
+      recordType: CNAME
+      targets: ["ipv4.${SECRET_DOMAIN}"]
+      providerSpecific:
+        - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
+          value: "false"

--- a/kubernetes/apps/media/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plex/app/helmrelease.yaml
@@ -1,0 +1,90 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: plex
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 1h
+  values:
+    controllers:
+      plex:
+        containers:
+          app:
+            image:
+              repository: plexinc/pms-docker
+              tag: 1.43.0.10492-121068a07
+            env:
+              TZ: America/Chicago
+              PLEX_UID: "1000"
+              PLEX_GID: "1000"
+              PLEX_ADVERTISE_URL: "https://plex.${SECRET_DOMAIN}:443,http://192.168.100.35:32400"
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /identity
+                    port: 32400
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+              readiness: *probes
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /identity
+                    port: 32400
+                  initialDelaySeconds: 10
+                  periodSeconds: 5
+                  failureThreshold: 30
+            resources:
+              requests:
+                cpu: 100m
+                memory: 2Gi
+                gpu.intel.com/i915: "1"
+              limits:
+                memory: 16Gi
+                gpu.intel.com/i915: "1"
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: false
+        runAsUser: 0
+        runAsGroup: 0
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        supplementalGroups:
+          - 44
+          - 105
+    service:
+      app:
+        controller: plex
+        type: LoadBalancer
+        annotations:
+          lbipam.cilium.io/ips: "192.168.100.35"
+        ports:
+          http:
+            primary: true
+            port: 32400
+    persistence:
+      config:
+        existingClaim: plex
+        globalMounts:
+          - path: /config
+      media:
+        type: nfs
+        server: snotra.internal
+        path: /mnt/user/media
+        globalMounts:
+          - path: /data/media
+            readOnly: true
+      transcode:
+        type: emptyDir
+        globalMounts:
+          - path: /transcode

--- a/kubernetes/apps/media/plex/app/kustomization.yaml
+++ b/kubernetes/apps/media/plex/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./dnsendpoint.yaml

--- a/kubernetes/apps/media/plex/ks.yaml
+++ b/kubernetes/apps/media/plex/ks.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app plex
+  namespace: &namespace media
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/volsync
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  interval: 1h
+  path: ./kubernetes/apps/media/plex/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 100Gi
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false


### PR DESCRIPTION
## Summary
- Deploy Plex Media Server with Intel QuickSync GPU transcoding
- LoadBalancer service on `192.168.100.35` (Cilium LBIPAM)
- DNSEndpoint with Cloudflare proxy disabled for direct client connections
- 100Gi VolSync PVC for metadata migration from existing Ubuntu host

## Dependencies
- Depends on #163 (NFS media path rename) — base branch is `feat/nfs-media-rename`

## Post-merge: Data Migration
After the PVC is created by VolSync:
1. Scale down Plex deployment
2. Run a temporary pod mounting the `plex` PVC
3. Copy 73GB of Plex data from Ubuntu host into the PVC
4. Scale Plex back up
5. Update library paths in Plex UI to `/data/media/*`
6. Stop Plex on Ubuntu host

## Test plan
- [ ] `flux get ks plex -n media` — Ready
- [ ] `kubectl get hr plex -n media` — Ready
- [ ] `kubectl get svc plex -n media` — LoadBalancer with 192.168.100.35
- [ ] `kubectl exec deploy/plex -n media -- ls /dev/dri` — GPU available
- [ ] `curl http://192.168.100.35:32400/identity` — responds
- [ ] Verify watch history and metadata preserved after data migration
- [ ] Test hardware transcoding (play 4K on 1080p client)

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)