### PR TITLE
feat(media): deploy audiobookshelf-hardcover-sync as booksync

### DIFF
--- a/kubernetes/apps/auth/authelia/app/externalsecret.yaml
+++ b/kubernetes/apps/auth/authelia/app/externalsecret.yaml
@@ -19,6 +19,7 @@ spec:
         OIDC_JWKS_KEY: "{{ .OIDC_JWKS_KEY }}"
         AUDIOBOOKSHELF_CLIENT_SECRET: "{{ .AUDIOBOOKSHELF_CLIENT_SECRET }}"
         SHELFMARK_CLIENT_SECRET: "{{ .SHELFMARK_CLIENT_SECRET }}"
+        BOOKSYNC_CLIENT_SECRET: "{{ .BOOKSYNC_CLIENT_SECRET }}"
         SMTP_USERNAME: "{{ .SMTP_USERNAME }}"
         LDAP_BASE_DN: "{{ .LDAP_BASE_DN }}"
   data:
@@ -46,6 +47,9 @@ spec:
     - secretKey: SHELFMARK_CLIENT_SECRET
       remoteRef:
         key: "a03e53fe-4c00-43be-af34-b400007db0f0"
+    - secretKey: BOOKSYNC_CLIENT_SECRET
+      remoteRef:
+        key: "d628e7dd-acbb-4451-bafc-b41501531809"
     - secretKey: SMTP_USERNAME
       remoteRef:
         key: "bd706631-16f1-481d-aeb0-b3fa00901c85"

--- a/kubernetes/apps/auth/authelia/app/resources/configuration.yml
+++ b/kubernetes/apps/auth/authelia/app/resources/configuration.yml
@@ -42,6 +42,7 @@ access_control:
     - domain:
         - 'books.${SECRET_DOMAIN}'
         - 'audiobookshelf.${SECRET_DOMAIN}'
+        - 'booksync.${SECRET_DOMAIN}'
         - 'shelfmark.${SECRET_DOMAIN}'
       subject:
         - 'group:books'
@@ -158,6 +159,19 @@ identity_providers:
         userinfo_signed_response_alg: 'none'
         token_endpoint_auth_method: 'none'
         pkce_challenge_method: S256
+      - client_id: booksync
+        client_name: Booksync
+        client_secret: '{{ secret "/secrets/authelia/BOOKSYNC_CLIENT_SECRET" }}'
+        public: false
+        authorization_policy: two_factor
+        consent_mode: implicit
+        scopes:
+          - openid
+          - groups
+          - email
+          - profile
+        redirect_uris:
+          - 'https://booksync.${SECRET_DOMAIN}/auth/callback/keycloak'
       - client_id: shelfmark
         client_name: Shelfmark
         client_secret: '{{ secret "/secrets/authelia/SHELFMARK_CLIENT_SECRET" }}'

--- a/kubernetes/apps/media/booksync/app/externalsecret.yaml
+++ b/kubernetes/apps/media/booksync/app/externalsecret.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: booksync
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: bitwarden-secretsmanager
+  target:
+    name: booksync-secret
+    template:
+      data:
+        KEYCLOAK_CLIENT_SECRET: "{{ .KEYCLOAK_CLIENT_SECRET }}"
+        ENCRYPTION_KEY: "{{ .ENCRYPTION_KEY }}"
+        AUTH_SESSION_SECRET: "{{ .AUTH_SESSION_SECRET }}"
+  data:
+    - secretKey: KEYCLOAK_CLIENT_SECRET
+      remoteRef:
+        key: "d628e7dd-acbb-4451-bafc-b41501531809"
+    - secretKey: ENCRYPTION_KEY
+      remoteRef:
+        key: "b4804cf4-cc10-4dc3-b97f-b4150153c1b2"
+    - secretKey: AUTH_SESSION_SECRET
+      remoteRef:
+        key: "2aabcbb7-23ff-45f5-8ca2-b4150153d489"

--- a/kubernetes/apps/media/booksync/app/helmrelease.yaml
+++ b/kubernetes/apps/media/booksync/app/helmrelease.yaml
@@ -1,0 +1,111 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: booksync
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 1h
+  values:
+    controllers:
+      booksync:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/drallgood/audiobookshelf-hardcover-sync
+              tag: v3.2.0
+            env:
+              TZ: America/Chicago
+              ENABLE_WEB_UI: "true"
+              LOG_LEVEL: info
+              DATA_DIR: /app/data
+              AUTH_ENABLED: "true"
+              KEYCLOAK_ENABLED: "true"
+              KEYCLOAK_ISSUER: "https://auth.${SECRET_DOMAIN}"
+              KEYCLOAK_CLIENT_ID: booksync
+              KEYCLOAK_REDIRECT_URI: "https://booksync.${SECRET_DOMAIN}/auth/callback/keycloak"
+              KEYCLOAK_SCOPES: "openid profile email groups"
+              KEYCLOAK_ROLE_CLAIM: groups
+            envFrom:
+              - secretRef:
+                  name: booksync-secret
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: &port 8080
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 3
+                  failureThreshold: 3
+              readiness: *probes
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: *port
+                  initialDelaySeconds: 5
+                  periodSeconds: 5
+                  failureThreshold: 30
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 10m
+                memory: 128Mi
+              limits:
+                memory: 256Mi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+    service:
+      app:
+        controller: booksync
+        ports:
+          http:
+            primary: true
+            port: *port
+    route:
+      app:
+        hostnames:
+          - "booksync.${SECRET_DOMAIN}"
+        parentRefs:
+          - name: envoy-external
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: *port
+    persistence:
+      data:
+        existingClaim: booksync
+        globalMounts:
+          - path: /app/data
+      cache:
+        type: emptyDir
+        globalMounts:
+          - path: /app/cache
+      mismatches:
+        type: emptyDir
+        globalMounts:
+          - path: /app/mismatches
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/media/booksync/app/kustomization.yaml
+++ b/kubernetes/apps/media/booksync/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./externalsecret.yaml

--- a/kubernetes/apps/media/booksync/ks.yaml
+++ b/kubernetes/apps/media/booksync/ks.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app booksync
+  namespace: &namespace media
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/gatus/guarded
+    - ../../../../components/volsync
+  dependsOn:
+    - name: audiobookshelf
+      namespace: media
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  interval: 1h
+  path: ./kubernetes/apps/media/booksync/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 1Gi
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false

--- a/kubernetes/apps/media/kustomization.yaml
+++ b/kubernetes/apps/media/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - ./mariadb/ks.yaml
   - ./audiobookshelf/ks.yaml
   - ./booklore/ks.yaml
+  - ./booksync/ks.yaml
   - ./plex/ks.yaml
   - ./prowlarr/ks.yaml
   - ./qbittorrent/ks.yaml


### PR DESCRIPTION
## Summary

- Deploy [audiobookshelf-hardcover-sync](https://github.com/drallgood/audiobookshelf-hardcover-sync) v3.2.0 as a standalone app in the media namespace at `booksync.${SECRET_DOMAIN}`
- Authelia OIDC SSO integration so any user in the `books` group can self-service their own ABS + Hardcover sync tokens via the web dashboard
- Hardened security context (`readOnlyRootFilesystem`, drop ALL capabilities, non-root 1000:1000)
- Volsync-backed 1Gi PVC for encrypted token database and sync state

## Changes

**New files:**
- `kubernetes/apps/media/booksync/` — Flux Kustomization, HelmRelease (app-template), ExternalSecret, Kustomization

**Modified files:**
- `kubernetes/apps/media/kustomization.yaml` — register booksync
- `kubernetes/apps/auth/authelia/app/resources/configuration.yml` — add `booksync` to books group ACL + OIDC client
- `kubernetes/apps/auth/authelia/app/externalsecret.yaml` — add `BOOKSYNC_CLIENT_SECRET` from Bitwarden

## Test plan

- [ ] Flux reconciles the new Kustomization without errors
- [ ] ExternalSecret syncs successfully from Bitwarden
- [ ] Pod starts and passes health checks (`/healthz`)
- [ ] HTTPRoute is accepted and DNS resolves
- [ ] Authelia OIDC login redirects correctly for books group users
- [ ] Users can add ABS/Hardcover tokens and trigger a sync
- [ ] Volsync ReplicationSource is created

Closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)