### PR TITLE
chore(spegel): remove dead service.registry.hostPort value

### DIFF
--- a/kubernetes/apps/kube-system/spegel/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/spegel/app/helmrelease.yaml
@@ -12,9 +12,6 @@ spec:
     spegel:
       containerdSock: /run/containerd/containerd.sock
       containerdRegistryConfigPath: /etc/cri/conf.d/hosts
-    service:
-      registry:
-        hostPort: 29999
     serviceMonitor:
       enabled: true
     grafanaDashboard:


### PR DESCRIPTION
## Summary

- Spegel chart 0.7.0 removed `hostPort` from the DaemonSet pod spec entirely in favor of NodePort-only access with `PreferSameNode` traffic distribution
- The `service.registry.hostPort: 29999` override was silently ignored after #255 merged
- Removing it so spegel uses the chart default `nodePort: 30020`

No port preference required — containerd's mirror config is dynamic via `containerdRegistryConfigPath` and follows whatever port spegel is using.

🤖 Generated with [Claude Code](https://claude.com/claude-code)