### PR TITLE
revert: Talos installer v1.12.6 ← v1.13.0 (revert #259)

### DIFF
--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   talos:
     # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
-    version: v1.13.0
+    version: v1.12.6
   policy:
     rebootMode: powercycle
   healthChecks:

--- a/talos/talenv.yaml
+++ b/talos/talenv.yaml
@@ -1,4 +1,4 @@
 # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
-talosVersion: v1.13.0
+talosVersion: v1.12.6
 # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
 kubernetesVersion: v1.35.3


### PR DESCRIPTION
## Summary
- Reverts #259, putting both `talos/talenv.yaml` and `kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml` back to `v1.12.6`.
- The 1.13.0 rollout failed on the first node (dvergar-00, control-plane). The node hung mid-upgrade — `talosctl dashboard` showed "upgrading" indefinitely; recovery required a manual power-cycle, after which the node booted back into 1.12.6 cleanly. tuppr retried and parked at `phase: Failed`.
- Suspected cause (not yet confirmed): nodes are installed via `factory.talos.dev/installer/dc8730aa…` (schematic with i915 GPU extension), but tuppr's TalosUpgrade spec specifies only `talos.version`, so it likely defaulted to the bare `ghcr.io/siderolabs/installer:v1.13.0` image. The bare image lacks the i915 schematic content, which may have caused the boot to hang.
- Reverting to unblock the cluster while the failure is investigated. PR #246 (kubelet 1.36) should remain on hold until Talos 1.13 is sorted.

## Cluster state at revert time
- 8/8 nodes Ready, all on Talos 1.12.6 / kernel 6.18.18 / kubelet 1.35.3 (pre-upgrade baseline).
- Ceph HEALTH_OK, 5/5 OSDs up+in.
- One residual `tuppr.home-operations.com/upgrading=true` label on dvergar-00 to be cleaned up after this merges.

## Test plan
- [ ] CI Flux Local checks pass.
- [ ] After merge: confirm tuppr's TalosUpgrade CR reconciles back to `version: v1.12.6` and stays in a non-progressing state (no nodes touched).
- [ ] After merge: remove stale `tuppr.home-operations.com/upgrading=true` label from dvergar-00.