### PR TITLE
feat(container): retry Talos installer v1.12.6 ➔ v1.13.0

### DIFF
--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   talos:
     # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
-    version: v1.12.6
+    version: v1.13.0
   policy:
     rebootMode: powercycle
   healthChecks:

--- a/talos/talenv.yaml
+++ b/talos/talenv.yaml
@@ -1,4 +1,4 @@
 # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
-talosVersion: v1.12.6
+talosVersion: v1.13.0
 # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
 kubernetesVersion: v1.35.3


### PR DESCRIPTION
## Summary
- Re-applies the version bump from #259 (reverted in #277) to retry the Talos 1.13.0 upgrade.
- No `nodeSelector` pinning — tuppr will pick up where it left off and likely target `dvergar-00` first (alphabetical, control-plane).
- Prior failure: dvergar-00 hung mid-upgrade and required manual power-cycle to recover. Likely Talos 1.13.0 issue (not tuppr/schematic — confirmed tuppr 0.1.13 already auto-detects the factory schematic from the `extensions.talos.dev/schematic` node annotation).
- Suspected related: [siderolabs/talos#12453](https://github.com/siderolabs/talos/issues/12453) (i915 regression on Alder Lake) or [#11830](https://github.com/siderolabs/talos/issues/11830) (talosctl upgrade API stream race).

## Test plan
- [ ] CI Flux Local checks pass
- [ ] After merge: watch tuppr roll the first node; if it hangs again, capture `talosctl -n <ip> dmesg --tail 500` and `talosctl -n <ip> logs machined` before recovery
- [ ] If first node succeeds: continue watching the rest of the rollout
- [ ] If first node fails: revert again (or pin to a worker for further isolation)