### PR TITLE
feat(talos): add 2.5G secondary NIC for ceph cluster network

### DIFF
--- a/talos/talconfig.yaml
+++ b/talos/talconfig.yaml
@@ -45,6 +45,13 @@ nodes:
         vlans:
           - vlanId: 70
             dhcp: false
+      - deviceSelector:
+          physical: true
+          hardwareAddr: "02:26:26:02:0d:7e"
+        dhcp: false
+        mtu: 9000
+        addresses:
+          - "10.10.10.20/24"
   - hostname: "dvergar-01"
     ipAddress: "192.168.100.21"
     installDiskSelector:
@@ -69,6 +76,13 @@ nodes:
         vlans:
           - vlanId: 70
             dhcp: false
+      - deviceSelector:
+          physical: true
+          hardwareAddr: "02:26:26:02:0d:d0"
+        dhcp: false
+        mtu: 9000
+        addresses:
+          - "10.10.10.21/24"
   - hostname: "dvergar-02"
     ipAddress: "192.168.100.22"
     installDiskSelector:
@@ -93,6 +107,13 @@ nodes:
         vlans:
           - vlanId: 70
             dhcp: false
+      - deviceSelector:
+          physical: true
+          hardwareAddr: "02:26:26:02:0d:20"
+        dhcp: false
+        mtu: 9000
+        addresses:
+          - "10.10.10.22/24"
   - hostname: "dvergar-03"
     ipAddress: "192.168.100.23"
     installDiskSelector:
@@ -115,6 +136,13 @@ nodes:
         vlans:
           - vlanId: 70
             dhcp: false
+      - deviceSelector:
+          physical: true
+          hardwareAddr: "02:26:26:02:0d:70"
+        dhcp: false
+        mtu: 9000
+        addresses:
+          - "10.10.10.23/24"
   - hostname: "dvergar-04"
     ipAddress: "192.168.100.24"
     installDiskSelector:
@@ -161,6 +189,13 @@ nodes:
         vlans:
           - vlanId: 70
             dhcp: false
+      - deviceSelector:
+          physical: true
+          hardwareAddr: "02:26:26:02:0d:ac"
+        dhcp: false
+        mtu: 9000
+        addresses:
+          - "10.10.10.25/24"
   - hostname: "dvergar-06"
     ipAddress: "192.168.100.26"
     installDiskSelector:


### PR DESCRIPTION
Refs #186 (Phase 1 of 2)

## Summary
- Adds a second `networkInterfaces` entry per OSD-hosting node (dvergar-00, 01, 02, 03, 05) for the new dedicated Ceph cluster network.
- Switch ports are configured **untagged** for the Ceph VLAN, so the IP sits directly on the parent interface (no VLAN wrapper in Talos config).
- MTU 9000 (jumbo) on the new NIC.
- No gateway / no routes — network is isolated behind a dedicated managed switch.

| Node | New NIC MAC | Cluster IP |
|---|---|---|
| dvergar-00 | `02:26:26:02:0d:7e` | 10.10.10.20/24 |
| dvergar-01 | `02:26:26:02:0d:d0` | 10.10.10.21/24 |
| dvergar-02 | `02:26:26:02:0d:20` | 10.10.10.22/24 |
| dvergar-03 | `02:26:26:02:0d:70` | 10.10.10.23/24 |
| dvergar-05 | `02:26:26:02:0d:ac` | 10.10.10.25/24 |

This is **Phase 1** of the Ceph network split — Talos templates only. Network changes hot-apply, no node reboots.

**Phase 2** (separate PR, will close #186) will set `cephClusterSpec.network.addressRanges.cluster: [\"10.10.10.0/24\"]` in `kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml` once all 5 nodes are confirmed reachable on the new subnet, then roll OSDs to bind to the new cluster_addr.

## Test plan
- [ ] CI Flux Local checks pass
- [ ] Regenerate machine configs with `talhelper genconfig` (run separately on the machine with secrets)
- [ ] `talosctl apply-config -n <ip> -f talos/clusterconfig/<host>.yaml` per OSD node (no reboot)
- [ ] Verify each OSD node has 10.10.10.x bound: \`talosctl -n <ip> get addresses | grep 10.10.10\`
- [ ] Verify L2 connectivity: from each OSD node, ping every other OSD node on its 10.10.10.x address
- [ ] Confirm jumbo frames work end-to-end: \`ping -M do -s 8972 <peer-ip>\` (8972 = 9000 - 28 byte ICMP/IP overhead)
- [ ] Only after all 5 verify clean: open Phase 2 PR for Rook