### PR TITLE
feat(rook-ceph): pin cluster network to dedicated 10.10.10.0/24

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -61,6 +61,9 @@ spec:
         provider: host
         connections:
           requireMsgr2: true
+        addressRanges:
+          cluster:
+            - "10.10.10.0/24"
       storage:
         useAllNodes: true
         useAllDevices: false


### PR DESCRIPTION
Closes #186 (Phase 2 of 2)

## Summary
- Sets `cephClusterSpec.network.addressRanges.cluster: ["10.10.10.0/24"]` so OSD-to-OSD traffic (replication, recovery, heartbeats) binds to the new 2.5G dedicated cluster network instead of the management subnet.
- Public network stays implicit on `192.168.100.0/24` — clients (CSI pods, mons↔OSDs) still use mgmt.
- Phase 1 (Talos templates) was #293, already merged. All 5 OSD nodes are confirmed reachable on `10.10.10.0/24` with jumbo frames working end-to-end.

## After this merges
Flux will reconcile the CephCluster CR. Existing OSD daemons keep running on their current bindings until restarted. The follow-up rollout (manual, one OSD at a time):

```bash
HOST=dvergar-00 OSD=2  # then 01/3, 02/1, 03/4, 05/0
kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph osd set-group noout $HOST
kubectl -n rook-ceph delete pod -l app=rook-ceph-osd,osd=$OSD
# wait for new pod Running 2/2
kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph osd dump | grep "^osd.$OSD"
# verify cluster_addr is now on 10.10.10.x
kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph osd unset-group noout $HOST
# wait for HEALTH_OK before next
```

## Test plan
- [ ] CI Flux Local checks pass
- [ ] After merge: Flux reconciles HelmRelease without errors
- [ ] CephCluster CR shows the new `addressRanges.cluster` value
- [ ] Roll OSDs one at a time per the procedure above
- [ ] Verify `ceph osd dump | grep cluster_addr` shows all 5 OSDs on `10.10.10.x`
- [ ] Verify `ceph osd dump | grep public_addr` still shows OSDs on `192.168.100.x`
- [ ] HEALTH_OK throughout