### PR TITLE
feat(musicseerr): deploy v1.3.4 on internal network

### DIFF
--- a/kubernetes/apps/media/kustomization.yaml
+++ b/kubernetes/apps/media/kustomization.yaml
@@ -22,6 +22,7 @@ resources:
   - ./lidarr/ks.yaml
   - ./maintainerr/ks.yaml
   - ./multi-scrobbler/ks.yaml
+  - ./musicseerr/ks.yaml
   - ./slskd/ks.yaml
   - ./sonarr/ks.yaml
   - ./sonarr4k/ks.yaml

--- a/kubernetes/apps/media/musicseerr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/musicseerr/app/helmrelease.yaml
@@ -1,0 +1,87 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: musicseerr
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 1h
+  values:
+    controllers:
+      musicseerr:
+        strategy: Recreate
+        containers:
+          app:
+            image:
+              repository: ghcr.io/habirabbu/musicseerr
+              tag: v1.3.4
+            env:
+              TZ: America/Chicago
+              PUID: "1000"
+              PGID: "1000"
+              PORT: &port 8688
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: *port
+                  initialDelaySeconds: 0
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness: *probes
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: *port
+                  initialDelaySeconds: 15
+                  periodSeconds: 5
+                  failureThreshold: 30
+            resources:
+              requests:
+                cpu: 10m
+                memory: 256Mi
+    defaultPodOptions:
+      securityContext:
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+    service:
+      app:
+        controller: musicseerr
+        ports:
+          http:
+            primary: true
+            port: *port
+    route:
+      app:
+        hostnames:
+          - "musicseerr.${SECRET_DOMAIN}"
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: *port
+    persistence:
+      config:
+        existingClaim: musicseerr
+        globalMounts:
+          - path: /app/config
+      cache:
+        type: emptyDir
+        globalMounts:
+          - path: /app/cache
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/media/musicseerr/app/kustomization.yaml
+++ b/kubernetes/apps/media/musicseerr/app/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/apps/media/musicseerr/ks.yaml
+++ b/kubernetes/apps/media/musicseerr/ks.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app musicseerr
+  namespace: &namespace media
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/gatus/guarded
+    - ../../../../components/volsync
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  interval: 1h
+  path: ./kubernetes/apps/media/musicseerr/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 2Gi
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false


### PR DESCRIPTION
## Summary

Closes #232. Adds [Musicseerr](https://github.com/HabiRabbu/Musicseerr) — a Lidarr-fronted music request, discovery, and playback app — modeled on the existing `lidarr` app.

- `ghcr.io/habirabbu/musicseerr:v1.3.4` on port 8688, single container, bjw-s app-template
- Internal-only ingress (`envoy-internal`) at `musicseerr.${SECRET_DOMAIN}` since this is single-user
- VolSync-backed config PVC (2Gi); cache and tmp as emptyDir
- All Lidarr / Jellyfin / ListenBrainz / Last.fm wiring is configured via the web UI after first start

## Test plan

- [ ] Flux reconciles the `musicseerr` Kustomization in the `media` namespace
- [ ] Pod becomes Ready (probes hit `/health` on 8688)
- [ ] VolSync provisions the `musicseerr` config PVC
- [ ] `https://musicseerr.${SECRET_DOMAIN}` resolves on the internal network and serves the UI
- [ ] Configure Lidarr URL + API key in Settings; confirm a search returns MusicBrainz results

🤖 Generated with [Claude Code](https://claude.com/claude-code)