### PR TITLE
feat(media): add pinchflat for YouTube → Plex

### DIFF
--- a/kubernetes/apps/media/kustomization.yaml
+++ b/kubernetes/apps/media/kustomization.yaml
@@ -23,6 +23,7 @@ resources:
   - ./maintainerr/ks.yaml
   - ./multi-scrobbler/ks.yaml
   - ./musicseerr/ks.yaml
+  - ./pinchflat/ks.yaml
   - ./slskd/ks.yaml
   - ./sonarr/ks.yaml
   - ./sonarr4k/ks.yaml

--- a/kubernetes/apps/media/pinchflat/app/helmrelease.yaml
+++ b/kubernetes/apps/media/pinchflat/app/helmrelease.yaml
@@ -1,0 +1,88 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: pinchflat
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 1h
+  values:
+    controllers:
+      pinchflat:
+        strategy: Recreate
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/kieraneglin/pinchflat
+              tag: v2025.9.26
+            env:
+              TZ: America/Chicago
+              EXPOSED_PORT: &port 8945
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: *port
+                  initialDelaySeconds: 10
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              readiness: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 10m
+                memory: 256Mi
+              limits:
+                memory: 2Gi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+    service:
+      app:
+        controller: pinchflat
+        ports:
+          http:
+            primary: true
+            port: *port
+    route:
+      app:
+        hostnames:
+          - "pinchflat.${SECRET_DOMAIN}"
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: *port
+    persistence:
+      config:
+        existingClaim: pinchflat
+        globalMounts:
+          - path: /config
+      media:
+        type: nfs
+        server: snotra.cluster
+        path: /mnt/user/media
+        globalMounts:
+          - path: /data/media
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/media/pinchflat/app/kustomization.yaml
+++ b/kubernetes/apps/media/pinchflat/app/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/apps/media/pinchflat/ks.yaml
+++ b/kubernetes/apps/media/pinchflat/ks.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app pinchflat
+  namespace: &namespace media
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/volsync
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  interval: 1h
+  path: ./kubernetes/apps/media/pinchflat/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 5Gi
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false


### PR DESCRIPTION
Internal-only deployment of pinchflat (yt-dlp wrapper) that writes
downloaded YouTube content to the shared snotra media share at
/data/media/youtube, where Plex's existing read-only mount will pick
it up after adding a library in the Plex UI.

Follows the existing *arr conventions: HelmRelease via app-template,
config PVC managed by VolSync (5Gi ceph-block), NFS media mount,
hardened security context, HTTPRoute on envoy-internal.