### PR TITLE
fix(media): pin pinchflat to v2025.6.6

### DIFF
--- a/kubernetes/apps/media/pinchflat/app/helmrelease.yaml
+++ b/kubernetes/apps/media/pinchflat/app/helmrelease.yaml
@@ -18,7 +18,7 @@ spec:
           app:
             image:
               repository: ghcr.io/kieraneglin/pinchflat
-              tag: v2025.9.26
+              tag: v2025.6.6
             env:
               TZ: America/Chicago
               EXPOSED_PORT: &port 8945


### PR DESCRIPTION
## Summary
- Fixes ImagePullBackOff on the pinchflat deployment merged in #315.
- `v2025.9.26` exists as a GitHub source release but was never published to `ghcr.io/kieraneglin/pinchflat`. The newest tag actually available there is `v2025.6.6`.

## Test plan
- [ ] Flux reconciles the HelmRelease without `ErrImagePull` / `ImagePullBackOff`
- [ ] `kubectl -n media get pod -l app.kubernetes.io/name=pinchflat` reports `Running`
- [ ] `https://pinchflat.${SECRET_DOMAIN}` loads the Pinchflat UI


---
_Generated by [Claude Code](https://claude.ai/code/session_01P85kyAuQvzDMEiCtm8KCuw)_