### PR TITLE
fix(media): add emptyDir at /downloads for pinchflat startup check

### DIFF
--- a/kubernetes/apps/media/pinchflat/app/helmrelease.yaml
+++ b/kubernetes/apps/media/pinchflat/app/helmrelease.yaml
@@ -82,6 +82,10 @@ spec:
         path: /mnt/user/media
         globalMounts:
           - path: /data/media
+      downloads:
+        type: emptyDir
+        globalMounts:
+          - path: /downloads
       tmp:
         type: emptyDir
         globalMounts:


### PR DESCRIPTION
## Summary
- Pinchflat performs a writable-permission check on its configured media directory at startup; on first boot this is the hardcoded default `/downloads`.
- Mount an `emptyDir` at `/downloads` so the check passes without disturbing the existing `/data/media` NFS convention used by the other media apps.
- After first start, set the Media directory in the Pinchflat UI to `/data/media/youtube`. Actual downloads then land on the snotra share where Plex's existing read-only mount already sees them.

## Test plan
- [ ] Flux reconciles the HelmRelease without errors
- [ ] `kubectl -n media get pod -l app.kubernetes.io/name=pinchflat` reports `Running` (no startup failure on `/downloads` perms)
- [ ] Pinchflat UI loads at `https://pinchflat.${SECRET_DOMAIN}`
- [ ] Set Media directory to `/data/media/youtube` in Settings, add a test source, confirm a downloaded file lands on snotra at `/mnt/user/media/youtube/...`
- [ ] New Plex library at `/data/media/youtube` sees the file


---
_Generated by [Claude Code](https://claude.ai/code/session_01P85kyAuQvzDMEiCtm8KCuw)_