### PR TITLE
fix(media): allow writable rootfs for pinchflat

### DIFF
--- a/kubernetes/apps/media/pinchflat/app/helmrelease.yaml
+++ b/kubernetes/apps/media/pinchflat/app/helmrelease.yaml
@@ -37,7 +37,6 @@ spec:
               readiness: *probes
             securityContext:
               allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: true
               capabilities: { drop: ["ALL"] }
             resources:
               requests:


### PR DESCRIPTION
## Summary
- Pinchflat writes to multiple paths under `/` at runtime (notably `/etc`) and isn't built for a read-only root filesystem.
- Drop `readOnlyRootFilesystem: true` rather than paper over each write location with emptyDir mounts.
- `runAsNonRoot: true`, `runAsUser: 1000`, `allowPrivilegeEscalation: false`, and `capabilities.drop: ["ALL"]` are all retained.

## Test plan
- [ ] Flux reconciles, pod reaches `Running` with no `/etc` write errors in logs
- [ ] Pinchflat UI loads at `https://pinchflat.${SECRET_DOMAIN}`
- [ ] Set Media directory to `/data/media/youtube`, add a test source, download lands on snotra


---
_Generated by [Claude Code](https://claude.ai/code/session_01P85kyAuQvzDMEiCtm8KCuw)_