### PR TITLE
fix(media): mount snotra NFS at /downloads for pinchflat

### DIFF
--- a/kubernetes/apps/media/pinchflat/app/helmrelease.yaml
+++ b/kubernetes/apps/media/pinchflat/app/helmrelease.yaml
@@ -80,10 +80,6 @@ spec:
         server: snotra.cluster
         path: /mnt/user/media
         globalMounts:
-          - path: /data/media
-      downloads:
-        type: emptyDir
-        globalMounts:
           - path: /downloads
       tmp:
         type: emptyDir


### PR DESCRIPTION
## Summary
- `/downloads` is pinchflat's hardcoded data directory — it's pinchflat's equivalent of `/data/media` on the `*arr` apps.
- Mount the snotra media share directly at `/downloads` and drop the placeholder emptyDir, so downloads persist on NFS without needing the user to override the media directory in the UI.

## Test plan
- [ ] Flux reconciles, pod stays `Running`
- [ ] Pinchflat UI loads; default Media directory is now backed by NFS
- [ ] Add a test source, confirm the file lands on snotra at `/mnt/user/media/<...>` (and at `/data/media/<...>` from Plex's view)
- [ ] Plex library picks up the content


---
_Generated by [Claude Code](https://claude.ai/code/session_01P85kyAuQvzDMEiCtm8KCuw)_