### PR TITLE
feat(talos): stable NIC names via LinkAliasConfig (mgmt0 / ceph0)

### DIFF
--- a/talos/patches/dvergar-00/link-alias.yaml
+++ b/talos/patches/dvergar-00/link-alias.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1alpha1
+kind: LinkAliasConfig
+name: mgmt0
+selector:
+  match: mac(link.permanent_addr) == "c0:25:a5:98:c0:f6"

--- a/talos/patches/dvergar-01/link-alias.yaml
+++ b/talos/patches/dvergar-01/link-alias.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1alpha1
+kind: LinkAliasConfig
+name: mgmt0
+selector:
+  match: mac(link.permanent_addr) == "14:b3:1f:2a:ec:95"

--- a/talos/patches/dvergar-02/link-alias.yaml
+++ b/talos/patches/dvergar-02/link-alias.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1alpha1
+kind: LinkAliasConfig
+name: mgmt0
+selector:
+  match: mac(link.permanent_addr) == "14:b3:1f:21:56:9c"

--- a/talos/patches/dvergar-03/link-alias.yaml
+++ b/talos/patches/dvergar-03/link-alias.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1alpha1
+kind: LinkAliasConfig
+name: mgmt0
+selector:
+  match: mac(link.permanent_addr) == "d8:9e:f3:9a:f8:4d"

--- a/talos/patches/dvergar-04/link-alias.yaml
+++ b/talos/patches/dvergar-04/link-alias.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1alpha1
+kind: LinkAliasConfig
+name: mgmt0
+selector:
+  match: mac(link.permanent_addr) == "48:4d:7e:d8:83:c8"

--- a/talos/patches/dvergar-05/link-alias.yaml
+++ b/talos/patches/dvergar-05/link-alias.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1alpha1
+kind: LinkAliasConfig
+name: mgmt0
+selector:
+  match: mac(link.permanent_addr) == "6c:2b:59:e4:ca:c8"

--- a/talos/patches/dvergar-06/link-alias.yaml
+++ b/talos/patches/dvergar-06/link-alias.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1alpha1
+kind: LinkAliasConfig
+name: mgmt0
+selector:
+  match: mac(link.permanent_addr) == "10:e7:c6:b1:1d:de"

--- a/talos/patches/elli/link-alias.yaml
+++ b/talos/patches/elli/link-alias.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1alpha1
+kind: LinkAliasConfig
+name: mgmt0
+selector:
+  match: mac(link.permanent_addr) == "0c:9d:92:85:2a:66"

--- a/talos/patches/global/link-aliases.yaml
+++ b/talos/patches/global/link-aliases.yaml
@@ -1,0 +1,8 @@
+---
+# Stable name for the 2.5G Intel I226-V card used as the Ceph cluster network.
+# Only the storage nodes have this card; non-storage nodes are an implicit no-op.
+apiVersion: v1alpha1
+kind: LinkAliasConfig
+name: ceph0
+selector:
+  match: link.driver == "igc" && mac(link.permanent_addr).startsWith("02:26:26:02:0d:")

--- a/talos/talconfig.yaml
+++ b/talos/talconfig.yaml
@@ -29,10 +29,10 @@ nodes:
       secureboot: false
     talosImageURL: factory.talos.dev/installer/dc8730aa8cc7bfa5ef7e2b3284248f2631135b2faf4ae11aa997a0c1987b0eee
     controlPlane: true
+    patches:
+      - "@./patches/dvergar-00/link-alias.yaml"
     networkInterfaces:
-      - deviceSelector:
-          physical: true
-          hardwareAddr: "c0:25:a5:98:c0:f6"
+      - interface: mgmt0
         dhcp: false
         addresses:
           - "192.168.100.20/24"
@@ -45,9 +45,7 @@ nodes:
         vlans:
           - vlanId: 70
             dhcp: false
-      - deviceSelector:
-          physical: true
-          hardwareAddr: "02:26:26:02:0d:7e"
+      - interface: ceph0
         dhcp: false
         mtu: 9000
         addresses:
@@ -60,10 +58,10 @@ nodes:
       secureboot: false
     talosImageURL: factory.talos.dev/installer/dc8730aa8cc7bfa5ef7e2b3284248f2631135b2faf4ae11aa997a0c1987b0eee
     controlPlane: true
+    patches:
+      - "@./patches/dvergar-01/link-alias.yaml"
     networkInterfaces:
-      - deviceSelector:
-          physical: true
-          hardwareAddr: "14:b3:1f:2a:ec:95"
+      - interface: mgmt0
         dhcp: false
         addresses:
           - "192.168.100.21/24"
@@ -76,9 +74,7 @@ nodes:
         vlans:
           - vlanId: 70
             dhcp: false
-      - deviceSelector:
-          physical: true
-          hardwareAddr: "02:26:26:02:0d:d0"
+      - interface: ceph0
         dhcp: false
         mtu: 9000
         addresses:
@@ -91,10 +87,10 @@ nodes:
       secureboot: false
     talosImageURL: factory.talos.dev/installer/dc8730aa8cc7bfa5ef7e2b3284248f2631135b2faf4ae11aa997a0c1987b0eee
     controlPlane: true
+    patches:
+      - "@./patches/dvergar-02/link-alias.yaml"
     networkInterfaces:
-      - deviceSelector:
-          physical: true
-          hardwareAddr: "14:b3:1f:21:56:9c"
+      - interface: mgmt0
         dhcp: false
         addresses:
           - "192.168.100.22/24"
@@ -107,9 +103,7 @@ nodes:
         vlans:
           - vlanId: 70
             dhcp: false
-      - deviceSelector:
-          physical: true
-          hardwareAddr: "02:26:26:02:0d:20"
+      - interface: ceph0
         dhcp: false
         mtu: 9000
         addresses:
@@ -122,10 +116,10 @@ nodes:
       secureboot: false
     talosImageURL: factory.talos.dev/installer/dc8730aa8cc7bfa5ef7e2b3284248f2631135b2faf4ae11aa997a0c1987b0eee
     controlPlane: false
+    patches:
+      - "@./patches/dvergar-03/link-alias.yaml"
     networkInterfaces:
-      - deviceSelector:
-          physical: true
-          hardwareAddr: "d8:9e:f3:9a:f8:4d"
+      - interface: mgmt0
         dhcp: false
         addresses:
           - "192.168.100.23/24"
@@ -136,9 +130,7 @@ nodes:
         vlans:
           - vlanId: 70
             dhcp: false
-      - deviceSelector:
-          physical: true
-          hardwareAddr: "02:26:26:02:0d:70"
+      - interface: ceph0
         dhcp: false
         mtu: 9000
         addresses:
@@ -151,10 +143,10 @@ nodes:
       secureboot: false
     talosImageURL: factory.talos.dev/installer/dc8730aa8cc7bfa5ef7e2b3284248f2631135b2faf4ae11aa997a0c1987b0eee
     controlPlane: false
+    patches:
+      - "@./patches/dvergar-04/link-alias.yaml"
     networkInterfaces:
-      - deviceSelector:
-          physical: true
-          hardwareAddr: "48:4d:7e:d8:83:c8"
+      - interface: mgmt0
         dhcp: false
         addresses:
           - "192.168.100.24/24"
@@ -175,10 +167,10 @@ nodes:
       secureboot: false
     talosImageURL: factory.talos.dev/installer/dc8730aa8cc7bfa5ef7e2b3284248f2631135b2faf4ae11aa997a0c1987b0eee
     controlPlane: false
+    patches:
+      - "@./patches/dvergar-05/link-alias.yaml"
     networkInterfaces:
-      - deviceSelector:
-          physical: true
-          hardwareAddr: "6c:2b:59:e4:ca:c8"
+      - interface: mgmt0
         dhcp: false
         addresses:
           - "192.168.100.25/25"
@@ -189,9 +181,7 @@ nodes:
         vlans:
           - vlanId: 70
             dhcp: false
-      - deviceSelector:
-          physical: true
-          hardwareAddr: "02:26:26:02:0d:ac"
+      - interface: ceph0
         dhcp: false
         mtu: 9000
         addresses:
@@ -204,10 +194,10 @@ nodes:
       secureboot: false
     talosImageURL: factory.talos.dev/installer/dc8730aa8cc7bfa5ef7e2b3284248f2631135b2faf4ae11aa997a0c1987b0eee
     controlPlane: false
+    patches:
+      - "@./patches/dvergar-06/link-alias.yaml"
     networkInterfaces:
-      - deviceSelector:
-          physical: true
-          hardwareAddr: "10:e7:c6:b1:1d:de"
+      - interface: mgmt0
         dhcp: false
         addresses:
           - "192.168.100.26/24"
@@ -228,10 +218,10 @@ nodes:
       secureboot: true
     talosImageURL: factory.talos.dev/installer/dc8730aa8cc7bfa5ef7e2b3284248f2631135b2faf4ae11aa997a0c1987b0eee
     controlPlane: false
+    patches:
+      - "@./patches/elli/link-alias.yaml"
     networkInterfaces:
-      - deviceSelector:
-          physical: true
-          hardwareAddr: "0c:9d:92:85:2a:66"
+      - interface: mgmt0
         dhcp: false
         addresses:
           - "192.168.100.30/25"
@@ -251,6 +241,7 @@ patches:
   - "@./patches/global/machine-sysctls.yaml"
   - "@./patches/global/machine-time.yaml"
   - "@./patches/global/machine-storage.yaml"
+  - "@./patches/global/link-aliases.yaml"
 
 # Controller patches
 controlPlane:


### PR DESCRIPTION
## Summary

Renames the management NIC to `mgmt0` on every node and the 2.5G Intel I226-V Ceph cluster-network NIC to `ceph0` on the 5 storage nodes that have it. Uses Talos's `LinkAliasConfig` document — a true kernel rename, visible to `ip link`, `/sys/class/net/`, node-exporter, multus `master`, etc.

## Why

dvergar-00 has a different motherboard chipset than the other dvergar nodes (Realtek RTL8111 onboard at PCI bus 2 vs Intel I219-V on the chipset at 0:1f.6). PCI enumeration pushes its Intel I226-V add-in card to `enp3s0`, while every other storage node has the same card at `enp2s0`. node-exporter reports the kernel IFNAME, the upstream `CephNodeInconsistentMTU` rule joins on `device` name, and the resulting one real mismatch fans out — via a `scalar()` collapse bug in the PromQL — to **178 firing alerts** across every interface in the cluster sharing the MTU-1500 value.

After this PR every node reports `mgmt0` (MTU 1500) and the storage nodes also report `ceph0` (MTU 9000). The join lines up, the rule goes quiet without needing to be suppressed, and future multus NetworkAttachmentDefinitions get a stable `master` target.

## Mapping

| Alias | Selector | Nodes |
|---|---|---|
| `ceph0` | `link.driver == "igc" && mac(...).startsWith("02:26:26:02:0d:")` (one global doc) | dvergar-00/01/02/03/05 — no-op on -04/-06/elli |
| `mgmt0` | MAC equality, per node | all 8 |

`networkInterfaces[]` entries previously selected by `deviceSelector.hardwareAddr` are switched to `interface: mgmt0` / `interface: ceph0` since the kernel name is now stable.

## Rollout plan

1. Merge.
2. `talhelper genconfig` to regenerate per-node machineconfigs.
3. Apply to **dvergar-04 first** (lowest blast radius — no Ceph OSD, no Ceph cluster NIC, just `mgmt0` rename).
4. Verify on -04:
   - `talosctl get links --nodes 192.168.100.24` shows `mgmt0` instead of `enp0s31f6` (or whatever it was)
   - `kubectl get node dvergar-04` stays `Ready`
   - Prometheus `node_network_mtu_bytes{device="mgmt0",kubernetes_node="dvergar-04"}` appears
5. If healthy, roll the remaining 7 nodes one at a time. Apply order suggestion: workers (-06, -03, -05, elli) → control planes (-00, -01, -02) last.
6. Watch for the `CephNodeInconsistentMTU` count to drop to zero after the last node lands.

## Revert path

If a node fails to come back after apply:
- `git revert` this commit
- `talhelper genconfig` to regenerate the old configs
- `talosctl apply-config` the previous config to the affected node

The old `deviceSelector.hardwareAddr` selectors still match the physical NIC regardless of name, so reverting recovers cleanly.

## References

- [Talos Link Aliases docs](https://docs.siderolabs.com/talos/v1.12/networking/configuration/aliases)
- [Talos issue #12738](https://github.com/siderolabs/talos/issues/12738) — confirms LinkAliasConfig is a true kernel rename
- [Talos discussion #8018](https://github.com/siderolabs/talos/discussions/8018) — confirms systemd-link / udev `NAME=` are not viable in Talos
- onedr0p's reference: [`talos/machineconfig.yaml.j2`](https://github.com/onedr0p/home-ops/blob/main/talos/machineconfig.yaml.j2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)