### PR TITLE
feat(db): scale single-instance CNPG clusters to 2 instances (closes #321)

### DIFF
--- a/kubernetes/apps/auth/authelia/db/cluster.yaml
+++ b/kubernetes/apps/auth/authelia/db/cluster.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     cnpg.io/skipEmptyWalArchiveCheck: "enabled"
 spec:
-  instances: 1
+  instances: 2
   imageName: ghcr.io/cloudnative-pg/postgresql:17
   storage:
     size: 5Gi

--- a/kubernetes/apps/auth/lldap/db/cluster.yaml
+++ b/kubernetes/apps/auth/lldap/db/cluster.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     cnpg.io/skipEmptyWalArchiveCheck: "enabled"
 spec:
-  instances: 1
+  instances: 2
   imageName: ghcr.io/cloudnative-pg/postgresql:17
   storage:
     size: 5Gi

--- a/kubernetes/apps/default/reactive-resume/db/cluster.yaml
+++ b/kubernetes/apps/default/reactive-resume/db/cluster.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     cnpg.io/skipEmptyWalArchiveCheck: "enabled"
 spec:
-  instances: 1
+  instances: 2
   imageName: ghcr.io/cloudnative-pg/postgresql:17
   storage:
     size: 5Gi

--- a/kubernetes/apps/default/vikunja/db/cluster.yaml
+++ b/kubernetes/apps/default/vikunja/db/cluster.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     cnpg.io/skipEmptyWalArchiveCheck: "enabled"
 spec:
-  instances: 1
+  instances: 2
   imageName: ghcr.io/cloudnative-pg/postgresql:17
   storage:
     size: 5Gi

--- a/kubernetes/apps/hermod/hermod-db/db/api-cluster.yaml
+++ b/kubernetes/apps/hermod/hermod-db/db/api-cluster.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     cnpg.io/skipEmptyWalArchiveCheck: "enabled"
 spec:
-  instances: 1
+  instances: 2
   imageName: ghcr.io/cloudnative-pg/postgresql:17
   storage:
     size: 5Gi

--- a/kubernetes/apps/hermod/hermod-db/db/auth-cluster.yaml
+++ b/kubernetes/apps/hermod/hermod-db/db/auth-cluster.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     cnpg.io/skipEmptyWalArchiveCheck: "enabled"
 spec:
-  instances: 1
+  instances: 2
   imageName: ghcr.io/cloudnative-pg/postgresql:17
   storage:
     size: 5Gi

--- a/kubernetes/apps/hermod/hermod-db/db/bot-cluster.yaml
+++ b/kubernetes/apps/hermod/hermod-db/db/bot-cluster.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     cnpg.io/skipEmptyWalArchiveCheck: "enabled"
 spec:
-  instances: 1
+  instances: 2
   imageName: ghcr.io/cloudnative-pg/postgresql:17
   storage:
     size: 5Gi


### PR DESCRIPTION
Closes #321.

## Summary

Bumps `spec.instances` from `1` to `2` on the 7 single-instance CNPG Postgres clusters. This eliminates the drain-blocker pattern documented in #321: Talos node drains were stalling on single-replica DB pods because their PDBs (managed by CNPG) allow zero disruptions when only one replica exists.

## Affected clusters

- `kubernetes/apps/auth/authelia/db/cluster.yaml` (`authelia-pg`)
- `kubernetes/apps/auth/lldap/db/cluster.yaml` (`lldap-pg`)
- `kubernetes/apps/default/reactive-resume/db/cluster.yaml` (`reactive-resume-pg`)
- `kubernetes/apps/default/vikunja/db/cluster.yaml` (`vikunja-pg`)
- `kubernetes/apps/hermod/hermod-db/db/api-cluster.yaml` (`hermod-api-pg`)
- `kubernetes/apps/hermod/hermod-db/db/auth-cluster.yaml` (`hermod-auth-pg`)
- `kubernetes/apps/hermod/hermod-db/db/bot-cluster.yaml` (`hermod-bot-pg`)

## What Flux/CNPG will do on reconcile

- CNPG provisions a new replica per cluster and brings it up via streaming replication from the existing primary. No primary downtime, no restart of the existing pod.
- Each new instance gets its own ceph-rbd PVC (`storage.storageClass: ceph-block`, `storage.size: 5Gi`). Storage overhead is modest — these DBs are all small (auth/identity, todo list, resume builder, Discord bot).
- Once a second replica is healthy, the CNPG-managed PDB will permit one voluntary disruption, unblocking future Talos node drains.

## Out of scope

The MariaDB (booklore) StatefulSet under `kubernetes/apps/media/mariadb/` has the same single-replica shape but is a different kind (Helm-chart StatefulSet, not a CNPG `Cluster`) requiring a different approach (Galera/replication topology, separate PDB story). Left for a follow-up.

## Test plan

- [ ] Flux reconciles each `Cluster` without errors
- [ ] CNPG provisions a second pod per cluster; replication catches up (`kubectl cnpg status <cluster>`)
- [ ] Each new replica gets its own ceph-rbd PVC bound
- [ ] PDB for each cluster reports `ALLOWED DISRUPTIONS: 1`
- [ ] Drain a Talos worker hosting one of these DBs — should complete without the stall described in #321

🤖 Generated with [Claude Code](https://claude.com/claude-code)