### PR TITLE
fix(reactive-resume): strip browserless printer controller (unblocks #288)

### DIFF
--- a/kubernetes/apps/default/reactive-resume/app/externalsecret.yaml
+++ b/kubernetes/apps/default/reactive-resume/app/externalsecret.yaml
@@ -15,9 +15,6 @@ spec:
         OAUTH_CLIENT_SECRET: "{{ .OAUTH_CLIENT_SECRET }}"
         S3_ACCESS_KEY_ID: "{{ .S3_ACCESS_KEY_ID }}"
         S3_SECRET_ACCESS_KEY: "{{ .S3_SECRET_ACCESS_KEY }}"
-        PRINTER_TOKEN: "{{ .PRINTER_TOKEN }}"
-        # Synthesized so the app and printer always agree on the token
-        PRINTER_ENDPOINT: "ws://reactive-resume-printer:3000?token={{ .PRINTER_TOKEN }}"
   data:
     - secretKey: AUTH_SECRET
       remoteRef:
@@ -31,6 +28,3 @@ spec:
     - secretKey: S3_SECRET_ACCESS_KEY
       remoteRef:
         key: "e30f2a9b-d114-4759-9a2c-b42a0001545d"
-    - secretKey: PRINTER_TOKEN
-      remoteRef:
-        key: "f0f71e27-0f5f-4d3f-8115-b42a0002d7bc"

--- a/kubernetes/apps/default/reactive-resume/app/helmrelease.yaml
+++ b/kubernetes/apps/default/reactive-resume/app/helmrelease.yaml
@@ -23,8 +23,6 @@ spec:
               NODE_ENV: production
               PORT: &port 3000
               APP_URL: "https://resume.${SECRET_DOMAIN}"
-              # Printer fetches pages from the app via the cluster-internal service
-              PRINTER_APP_URL: "http://reactive-resume:3000"
               # OIDC (Authelia) — discovery handles auth/token/userinfo
               OAUTH_PROVIDER_NAME: Authelia
               OAUTH_CLIENT_ID: reactive-resume
@@ -35,7 +33,6 @@ spec:
               # actual access gate)
               FLAG_DISABLE_SIGNUPS: "false"
               FLAG_DISABLE_EMAIL_AUTH: "true"
-              FLAG_DEBUG_PRINTER: "false"
               FLAG_DISABLE_IMAGE_PROCESSING: "false"
               # S3 (Garage) — file uploads bucket
               S3_REGION: garage
@@ -50,7 +47,7 @@ spec:
                     key: uri
             envFrom:
               # AUTH_SECRET, OAUTH_CLIENT_SECRET, S3_ACCESS_KEY_ID,
-              # S3_SECRET_ACCESS_KEY, PRINTER_ENDPOINT, PRINTER_TOKEN
+              # S3_SECRET_ACCESS_KEY
               - secretRef:
                   name: reactive-resume-secret
             probes:
@@ -74,43 +71,6 @@ spec:
                 cpu: 50m
               limits:
                 memory: 1Gi
-      printer:
-        annotations:
-          reloader.stakater.com/auto: "true"
-        containers:
-          app:
-            image:
-              repository: ghcr.io/browserless/chromium
-              tag: v2.49.0
-            env:
-              TIMEOUT: "10000"
-              CONCURRENT: "10"
-              QUEUED: "10"
-              HEALTH: "true"
-              EXIT_ON_HEALTH_FAILURE: "true"
-              TOKEN:
-                valueFrom:
-                  secretKeyRef:
-                    name: reactive-resume-secret
-                    key: PRINTER_TOKEN
-            probes:
-              # /pressure requires the token; use TCP probe instead
-              liveness: &printerProbes
-                enabled: true
-                custom: true
-                spec:
-                  tcpSocket:
-                    port: 3000
-                  initialDelaySeconds: 30
-                  periodSeconds: 30
-                  timeoutSeconds: 5
-                  failureThreshold: 5
-              readiness: *printerProbes
-            resources:
-              requests:
-                cpu: 100m
-              limits:
-                memory: 1Gi
     defaultPodOptions:
       enableServiceLinks: false
     service:
@@ -119,11 +79,6 @@ spec:
         ports:
           http:
             port: *port
-      printer:
-        controller: printer
-        ports:
-          http:
-            port: 3000
     route:
       app:
         hostnames:


### PR DESCRIPTION
## Summary

Upstream reactive-resume **v5.1.x removes the standalone Browserless/Chromium "printer" service** — PDF rendering is now handled inside the main app process. To unblock Renovate PR #288 (which bumps `ghcr.io/amruthpillai/reactive-resume` `v5.0.20` -> `v5.1.5`), the printer side-car has to come out of our manifests first; otherwise the HelmRelease would still be wiring a now-defunct controller against the new image and the related env vars / secret keys would be dead weight.

This PR is the prep step. It is intentionally a no-op against the running v5.0.20 app except that the printer controller is removed — the app will continue to serve normally, only PDF export via the side-car goes away. Once this lands, Renovate's #288 can be merged to actually upgrade the image.

### What changed

- `kubernetes/apps/default/reactive-resume/app/helmrelease.yaml`
  - Removed the `printer:` controller block (`ghcr.io/browserless/chromium`)
  - Removed the `service.printer` entry
  - Removed `PRINTER_APP_URL` and `FLAG_DEBUG_PRINTER` env vars from the app container
  - Updated the `envFrom` comment to drop `PRINTER_ENDPOINT` / `PRINTER_TOKEN`
- `kubernetes/apps/default/reactive-resume/app/externalsecret.yaml`
  - Removed the `PRINTER_TOKEN` and synthesized `PRINTER_ENDPOINT` from `target.template.data`
  - Removed the `PRINTER_TOKEN` entry from `data[]` (the Bitwarden vault item is left untouched)

App controller, app Service, route, port `3000`, `/api/health` probe, `DATABASE_URL`, `S3_*`, and `OAUTH_*` are all untouched.

Refs #320 (the hold issue tracking this prep work).

## Pre-merge action required from operator

**Before merging this PR, take a CNPG backup of the `reactive-resume-pg` cluster.** The follow-up merge (Renovate #288, `v5.0.20` -> `v5.1.5`) applies a forward-only DB migration with no automatic rollback path, so a known-good backup is the safety net.

Suggested:

```sh
kubectl -n default cnpg backup reactive-resume-pg --backup-name pre-v5.1.5-upgrade
```

(or whatever CNPG plugin / Barman flow you use locally).

This PR alone does not touch the DB schema or the app image, so it can be merged safely once the backup is confirmed.

## Follow-ups after this PR + #288 merge

- Close **#279** (Renovate patch bump for `ghcr.io/browserless/chromium`) — browserless/chromium is no longer referenced anywhere in the repo after this PR, so the patch PR has nothing to apply to.

## Test plan

- [ ] `flux diff` / kustomize build clean against the cluster
- [ ] HelmRelease reconciles; `reactive-resume-printer` Deployment + Service are removed
- [ ] `reactive-resume` app pod stays Ready; `/api/health` continues to pass
- [ ] `reactive-resume-secret` no longer contains `PRINTER_TOKEN` / `PRINTER_ENDPOINT` keys after the next ExternalSecret refresh
- [ ] CNPG backup of `reactive-resume-pg` captured before merging Renovate #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)