### PR TITLE
feat(observability): add VictoriaLogs alongside Loki (PR A)

### DIFF
--- a/kubernetes/apps/observability/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/grafana/app/helmrelease.yaml
@@ -65,6 +65,11 @@ spec:
             url: http://loki-headless.observability.svc.cluster.local:3100
             jsonData:
               maxLines: 250
+          - name: VictoriaLogs
+            type: victoriametrics-logs-datasource
+            uid: vlogs
+            access: proxy
+            url: http://victoria-logs.observability.svc.cluster.local:9428
           - name: Tempo
             type: tempo
             uid: tempo
@@ -260,6 +265,7 @@ spec:
       - grafana-piechart-panel
       - grafana-worldmap-panel
       - pr0ps-trackmap-panel
+      - victoriametrics-logs-datasource
     serviceMonitor:
       enabled: true
     route:

--- a/kubernetes/apps/observability/kustomization.yaml
+++ b/kubernetes/apps/observability/kustomization.yaml
@@ -12,3 +12,4 @@ resources:
   - ./opentelemetry-collector/ks.yaml
   - ./promtail/ks.yaml
   - ./tempo/ks.yaml
+  - ./victoria-logs/ks.yaml

--- a/kubernetes/apps/observability/opentelemetry-collector/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/opentelemetry-collector/app/helmrelease.yaml
@@ -61,8 +61,8 @@ spec:
           endpoint: http://prometheus-operated.observability.svc.cluster.local:9090/api/v1/write
           tls:
             insecure: true
-        otlphttp/loki:
-          endpoint: http://loki-headless.observability.svc.cluster.local:3100/otlp
+        otlphttp/victorialogs:
+          logs_endpoint: http://victoria-logs.observability.svc.cluster.local:9428/insert/opentelemetry/v1/logs
           tls:
             insecure: true
       service:
@@ -75,4 +75,4 @@ spec:
             exporters: [prometheusremotewrite, otlp/aspire]
           logs:
             receivers: [otlp]
-            exporters: [otlphttp/loki, otlp/aspire]
+            exporters: [otlphttp/victorialogs, otlp/aspire]

--- a/kubernetes/apps/observability/victoria-logs/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-logs/app/helmrelease.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: victoria-logs
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: victoria-logs
+  values:
+    global:
+      image:
+        registry: quay.io
+    dashboards:
+      enabled: true
+      labels:
+        grafana_dashboard: "1"
+    server:
+      fullnameOverride: victoria-logs
+      persistentVolume:
+        enabled: true
+        storageClassName: ceph-block
+        size: 50Gi
+      retentionPeriod: 90d
+      route:
+        enabled: true
+        hostnames:
+          - vlogs.${SECRET_DOMAIN}
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
+      serviceMonitor:
+        enabled: true

--- a/kubernetes/apps/observability/victoria-logs/app/kustomization.yaml
+++ b/kubernetes/apps/observability/victoria-logs/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/observability/victoria-logs/app/ocirepository.yaml
+++ b/kubernetes/apps/observability/victoria-logs/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: victoria-logs
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.12.5
+  url: oci://ghcr.io/victoriametrics/helm-charts/victoria-logs-single

--- a/kubernetes/apps/observability/victoria-logs/collector/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-logs/collector/helmrelease.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: victoria-logs-collector
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: victoria-logs-collector
+  values:
+    fullnameOverride: victoria-logs-collector
+    global:
+      image:
+        registry: quay.io
+    podMonitor:
+      enabled: true
+    remoteWrite:
+      - url: http://victoria-logs.observability.svc.cluster.local:9428

--- a/kubernetes/apps/observability/victoria-logs/collector/kustomization.yaml
+++ b/kubernetes/apps/observability/victoria-logs/collector/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/observability/victoria-logs/collector/ocirepository.yaml
+++ b/kubernetes/apps/observability/victoria-logs/collector/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: victoria-logs-collector
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.3.4
+  url: oci://ghcr.io/victoriametrics/helm-charts/victoria-logs-collector

--- a/kubernetes/apps/observability/victoria-logs/ks.yaml
+++ b/kubernetes/apps/observability/victoria-logs/ks.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: victoria-logs
+  namespace: &namespace observability
+spec:
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  interval: 1h
+  path: ./kubernetes/apps/observability/victoria-logs/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  wait: false
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: victoria-logs-collector
+  namespace: &namespace observability
+spec:
+  dependsOn:
+    - name: victoria-logs
+  interval: 1h
+  path: ./kubernetes/apps/observability/victoria-logs/collector
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  wait: false


### PR DESCRIPTION
## Summary

PR A of the VictoriaLogs migration from issue #273. Stands up VictoriaLogs + `victoria-logs-collector` side-by-side with the existing Loki + Promtail stack so we can validate the new logs store before retiring Loki in a follow-up PR.

- New `kubernetes/apps/observability/victoria-logs/` (app + collector), modeled on `onedr0p/home-ops` `kubernetes/apps/o11y/victoria-logs/`
  - `victoria-logs-single` chart `0.12.5`, 50 Gi `ceph-block`, 90 d retention, HTTPRoute at `vlogs.${SECRET_DOMAIN}` via `envoy-internal`
  - `victoria-logs-collector` chart `0.3.4`, remoteWrites to the VL service
  - `dashboards.enabled: true` with `grafana_dashboard` label so our sidecar picks the bundled dashboard up automatically
- Grafana: add `victoriametrics-logs-datasource` plugin + a `VictoriaLogs` datasource (uid `vlogs`). Loki datasource stays so dashboards keep working
- OTel collector: replace the `otlphttp/loki` exporter with `otlphttp/victorialogs` (full path via `logs_endpoint`). Promtail keeps shipping pod logs to Loki during the dual-shipping window

PR B will delete `loki/` + `promtail/`, drop the Loki datasource, and fix any dashboard refs once VL is verified.

Closes nothing yet — #271 closes with PR B.

## Test plan

- [ ] Flux reconciles `victoria-logs` and `victoria-logs-collector` Kustomizations cleanly
- [ ] `victoria-logs-0` Pod becomes Ready; PVC bound to `ceph-block`
- [ ] `victoria-logs-collector` DaemonSet runs on every node
- [ ] `https://vlogs.${SECRET_DOMAIN}` reachable on the internal gateway
- [ ] Grafana shows `VictoriaLogs` datasource and a query returns recent pod logs
- [ ] OTel-sourced logs land in VictoriaLogs (check via the `_stream` selector for an OTLP-emitting app)
- [ ] Promtail still ships to Loki; existing Loki-backed dashboards keep working

🤖 Generated with [Claude Code](https://claude.com/claude-code)