### PR TITLE
fix(observability): substitute SECRET_DOMAIN in victoria-logs ks

### DIFF
--- a/kubernetes/apps/observability/victoria-logs/ks.yaml
+++ b/kubernetes/apps/observability/victoria-logs/ks.yaml
@@ -10,6 +10,10 @@ spec:
       namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/observability/victoria-logs/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository


### PR DESCRIPTION
## Summary

PR A landed but the victoria-logs HelmRelease is failing because the Kustomization had no `postBuild.substituteFrom`, so `vlogs.\${SECRET_DOMAIN}` reached the API server literal and HTTPRoute admission rejected it. Add the cluster-secrets substitution like every other app-with-a-route does.

## Test plan

- [ ] Flux reconciles \`victoria-logs\` HR cleanly after merge
- [ ] HTTPRoute \`victoria-logs\` has the substituted hostname
- [ ] \`https://vlogs.\${SECRET_DOMAIN}\` reachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)