### PR TITLE
fix(rook-ceph): strip CephNodeInconsistentMTU PromQL alert

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -24,6 +24,24 @@ spec:
   chartRef:
     kind: OCIRepository
     name: rook-ceph-cluster
+  postRenderers:
+    # Strip CephNodeInconsistentMTU — upstream rule's scalar(max by(device)…)
+    # comparison fires false-positives on our cluster (heterogeneous NIC layouts
+    # across nodes). `test` ops fail loudly if Rook reorders rules so we re-pin.
+    - kustomize:
+        patches:
+          - target:
+              kind: PrometheusRule
+              name: prometheus-ceph-rules
+            patch: |
+              - op: test
+                path: /spec/groups/6/name
+                value: nodes
+              - op: test
+                path: /spec/groups/6/rules/5/alert
+                value: CephNodeInconsistentMTU
+              - op: remove
+                path: /spec/groups/6/rules/5
   values:
     monitoring:
       enabled: true


### PR DESCRIPTION
## Summary

Strip `CephNodeInconsistentMTU` from the rendered `prometheus-ceph-rules` PrometheusRule via a `postRenderers` JSON6902 patch on the `rook-ceph-cluster` HelmRelease.

The upstream rule's `scalar(max by(device) (...))` comparison false-positives against our heterogeneous NIC layouts and has never represented real MTU drift here. Disabling rather than patching the query — re-enable by deleting the postRenderer block if/when alert is actually useful.

`test` ops on `groups[6].name == nodes` and `groups[6].rules[5].alert == CephNodeInconsistentMTU` guard against silent rule removal: a future Rook chart bump that reorders rules will fail reconcile loudly, prompting an index re-pin.

## Test plan

- [ ] Flux reconciles \`rook-ceph-cluster\` HR cleanly after merge
- [ ] \`kubectl -n rook-ceph get prometheusrule prometheus-ceph-rules -o json | jq '[.spec.groups[].rules[].alert] | index("CephNodeInconsistentMTU")'\` returns \`null\`
- [ ] Existing \`CephNodeInconsistentMTU\` alert in Alertmanager clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)