### PR TITLE
feat(kube-system): add multus chart (no NADs yet)

### DIFF
--- a/kubernetes/apps/kube-system/kustomization.yaml
+++ b/kubernetes/apps/kube-system/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - ./cilium/ks.yaml
   - ./coredns/ks.yaml
   - ./metrics-server/ks.yaml
+  - ./multus/ks.yaml
   - ./reloader/ks.yaml
   # - ./spegel/ks.yaml
   - ./reflector/ks.yaml

--- a/kubernetes/apps/kube-system/multus/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/multus/app/helmrelease.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: multus
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: multus
+  interval: 1h
+  values:
+    cni:
+      binPath: /opt/cni/bin
+      netPath: /etc/cni/net.d
+    multus:
+      resources:
+        requests:
+          cpu: 10m
+        limits:
+          memory: 512Mi

--- a/kubernetes/apps/kube-system/multus/app/kustomization.yaml
+++ b/kubernetes/apps/kube-system/multus/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/kube-system/multus/app/ocirepository.yaml
+++ b/kubernetes/apps/kube-system/multus/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: multus
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 1.3.2
+  url: oci://ghcr.io/bjw-s-labs/helm/multus

--- a/kubernetes/apps/kube-system/multus/ks.yaml
+++ b/kubernetes/apps/kube-system/multus/ks.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: multus
+  namespace: &namespace kube-system
+spec:
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: multus
+      namespace: kube-system
+    - apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      name: network-attachment-definitions.k8s.cni.cncf.io
+  interval: 1h
+  path: ./kubernetes/apps/kube-system/multus/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  wait: false


### PR DESCRIPTION
## Summary

PR 1 of the multus migration. Deploys the \`bjw-s-labs/helm/multus\` chart (v1.3.2) on every node. multus-cni DaemonSet runs alongside Cilium in chained mode — pods still get their primary network from Cilium as normal, multus only kicks in for pods that opt in via \`k8s.v1.cni.cncf.io/networks\` annotation.

This PR ships **no NetworkAttachmentDefinitions** and **no consumer pods**, so existing workloads are unaffected. The chart deploy is a no-op until something opts in.

PR 2 will add the VPN NAD + a test pod on dvergar-06 to validate the multus + VLAN 70 + OPNsense data path before any real workload migration.

Refs #269 (cilium hold), #270 (gluetun hold).

## Test plan

- [ ] Flux reconciles \`multus\` Kustomization cleanly
- [ ] HelmRelease \`multus\` becomes Ready
- [ ] \`network-attachment-definitions.k8s.cni.cncf.io\` CRD installed (Kustomization healthCheck verifies this)
- [ ] \`multus\` DaemonSet runs on every node (\`kubectl -n kube-system get ds multus\`)
- [ ] Existing pods unaffected — random spot-check (\`kubectl get pods -A | grep -vE 'Running|Completed'\` returns empty)
- [ ] Cilium agent pods on every node still Ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)