### PR TITLE
fix(home-automation): skip zigbee2mqtt onboarding server (headless)

### DIFF
--- a/kubernetes/apps/home-automation/zigbee2mqtt/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/zigbee2mqtt/app/helmrelease.yaml
@@ -21,6 +21,9 @@ spec:
             env:
               TZ: America/Chicago
               ZIGBEE2MQTT_DATA: /data
+              # Z2M 2.x first-run onboarding server gates startup; skip it so Z2M
+              # boots headless straight from the env config below (GitOps).
+              Z2M_ONBOARD_NO_SERVER: "1"
               ZIGBEE2MQTT_CONFIG_FRONTEND_ENABLED: "true"
               ZIGBEE2MQTT_CONFIG_FRONTEND_PORT: "8080"
               ZIGBEE2MQTT_CONFIG_HOMEASSISTANT_ENABLED: "true"


### PR DESCRIPTION
Follow-up to #349. Z2M 2.x ships a first-run **onboarding server** that gates startup — the pod logged `Onboarding page is available at http://0.0.0.0:8080/` and never connected to the coordinator, even though the env config (`tcp://slzb.internal:6638`, `adapter: ember`) was correct.

`Z2M_ONBOARD_NO_SERVER=1` disables the onboarding server (supersedes other onboarding settings) so Z2M boots headless straight from the provided env config — the GitOps path.

Refs #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)