### PR TITLE
feat(home-automation): set zigbee2mqtt channel to 15

### DIFF
--- a/kubernetes/apps/home-automation/zigbee2mqtt/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/zigbee2mqtt/app/helmrelease.yaml
@@ -32,6 +32,9 @@ spec:
               # DNS alias follows the device across its physical move (no IP to update).
               ZIGBEE2MQTT_CONFIG_SERIAL_PORT: tcp://slzb.internal:6638
               ZIGBEE2MQTT_CONFIG_SERIAL_ADAPTER: ember
+              # Zigbee channel 15 sits in the gap between WiFi ch 1/6. Set before
+              # pairing any devices — changing it later forces a full re-pair.
+              ZIGBEE2MQTT_CONFIG_ADVANCED_CHANNEL: "15"
             probes:
               liveness: &probes
                 enabled: true


### PR DESCRIPTION
Pins the Zigbee network channel to **15** via `ZIGBEE2MQTT_CONFIG_ADVANCED_CHANNEL`.

Z2M formed its initial network on the default channel 11 (overlaps WiFi ch 1). With **0 devices joined**, re-forming onto channel 15 (a gap between WiFi 1/6) is free now — after devices are paired, a channel change forces a full re-pair. Coordinator is in its final physical location.

Refs #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)