### PR TITLE
fix(media): update pinchflat ( v2025.6.6 ➔ v2025.9.26 )

### DIFF
--- a/kubernetes/apps/media/pinchflat/app/helmrelease.yaml
+++ b/kubernetes/apps/media/pinchflat/app/helmrelease.yaml
@@ -18,7 +18,7 @@ spec:
           app:
             image:
               repository: ghcr.io/kieraneglin/pinchflat
-              tag: v2025.6.6
+              tag: v2025.9.26
             env:
               TZ: America/Chicago
               EXPOSED_PORT: &port 8945


### PR DESCRIPTION
## What
Bumps the pinchflat image `v2025.6.6` → `v2025.9.26`.

## Why
yt-dlp now requires a JavaScript runtime (Deno) for YouTube extraction. The running `v2025.6.6` image predates this, so downloads log:

```
WARNING: [youtube] No supported JavaScript runtime could be found. Only deno is enabled by default...
```

`v2025.9.26`'s sole change is **"Add Deno to Dockerfiles"** (kieraneglin/pinchflat#801) — it exists specifically to fix this. No config migration; the release's ⚠️ "see #800" note is just a maintainer development-pause notice, not a breaking change.

This clears the JS-runtime warning and lets extraction succeed first-try, reducing the retry storms that were compounding the HTTP 429 rate-limiting. (429 backoff/cookies handled separately in pinchflat settings.)

## Verification
- [ ] Flux reconciles the HelmRelease, pinchflat pod restarts on `v2025.9.26`
- [ ] New download logs no longer show "No supported JavaScript runtime"

🤖 Generated with [Claude Code](https://claude.com/claude-code)