### PR TITLE
fix(media): pin pinchflat to latest@digest (v2025.9.26 image never published)

### DIFF
--- a/kubernetes/apps/media/pinchflat/app/helmrelease.yaml
+++ b/kubernetes/apps/media/pinchflat/app/helmrelease.yaml
@@ -18,7 +18,10 @@ spec:
           app:
             image:
               repository: ghcr.io/kieraneglin/pinchflat
-              tag: v2025.9.26
+              # No versioned image is published after v2025.6.6 (maintainer dev-pause,
+              # kieraneglin/pinchflat#800); the Deno fix (#801) only ships on `latest`.
+              # Pin latest by digest for reproducibility.
+              tag: latest@sha256:01b4f98aabaf3f5fe394213f7a32578c9e84e42080f52e2f8334021a4473b202
             env:
               TZ: America/Chicago
               EXPOSED_PORT: &port 8945


### PR DESCRIPTION
## What
Replaces the broken `tag: v2025.9.26` with `tag: latest@sha256:01b4f98aabaf3f5fe394213f7a32578c9e84e42080f52e2f8334021a4473b202`.

## Why — corrects #352
#352 bumped to the **release** tag `v2025.9.26`, but pinchflat **never published a matching container image**. The maintainer is on a development pause (kieraneglin/pinchflat#800) and stopped cutting versioned image builds after `v2025.6.6` — the Deno fix (#801) only lands on the `latest` tag.

Result: `ghcr.io/kieraneglin/pinchflat:v2025.9.26` → `not found` → `ImagePullBackOff` → pinchflat down.

ghcr tag check confirmed the only post-6.6 build is `latest` (digest `sha256:01b4f98a…`). Pinning `latest` by digest:
- restores service with the **Deno-enabled** build (the original goal — fixes the JS-runtime errors)
- stays reproducible + Renovate-trackable
- matches existing `@sha256` digest-pin convention in the repo (grafana, gatus, shelfmark)

## Verification
- [ ] Flux reconciles, pinchflat pod pulls and runs `latest@sha256:01b4f98a…`
- [ ] Logs no longer show "No supported JavaScript runtime"

🤖 Generated with [Claude Code](https://claude.com/claude-code)