### PR TITLE
feat(cnpg): flip reactive-resume + vikunja to recovery bootstrap

### DIFF
--- a/kubernetes/apps/default/reactive-resume/db/cluster.yaml
+++ b/kubernetes/apps/default/reactive-resume/db/cluster.yaml
@@ -18,15 +18,21 @@ spec:
     requests:
       cpu: 50m
   bootstrap:
-    initdb:
-      database: reactive_resume
-      owner: reactive_resume
+    recovery:
+      source: reactive-resume-pg-v1
   plugins:
     - name: barman-cloud.cloudnative-pg.io
       isWALArchiver: true
       parameters:
         barmanObjectName: reactive-resume-pg-backup
         serverName: reactive-resume-pg-v1
+  externalClusters:
+    - name: reactive-resume-pg-v1
+      plugin:
+        name: barman-cloud.cloudnative-pg.io
+        parameters:
+          barmanObjectName: reactive-resume-pg-backup
+          serverName: reactive-resume-pg-v1
 ---
 apiVersion: barmancloud.cnpg.io/v1
 kind: ObjectStore

--- a/kubernetes/apps/default/vikunja/db/cluster.yaml
+++ b/kubernetes/apps/default/vikunja/db/cluster.yaml
@@ -18,15 +18,21 @@ spec:
     requests:
       cpu: 50m
   bootstrap:
-    initdb:
-      database: vikunja
-      owner: vikunja
+    recovery:
+      source: vikunja-pg-v1
   plugins:
     - name: barman-cloud.cloudnative-pg.io
       isWALArchiver: true
       parameters:
         barmanObjectName: vikunja-pg-backup
         serverName: vikunja-pg-v1
+  externalClusters:
+    - name: vikunja-pg-v1
+      plugin:
+        name: barman-cloud.cloudnative-pg.io
+        parameters:
+          barmanObjectName: vikunja-pg-backup
+          serverName: vikunja-pg-v1
 ---
 apiVersion: barmancloud.cnpg.io/v1
 kind: ObjectStore


### PR DESCRIPTION
## What

Switch the `reactive-resume-pg` and `vikunja-pg` CNPG clusters from `bootstrap: initdb` to `bootstrap: recovery`, and add the matching `externalClusters` entry pointing at their existing barman ObjectStore — mirroring the `authelia-pg` / `lldap-pg` pattern.

## Why

Both clusters were originally created with `initdb` (correct — `recovery` can't bootstrap when no backup exists yet) and have since accumulated daily barman backups in Garage (16 completed each, newest <1d old). But their bootstrap was never flipped to `recovery`. On a from-scratch cluster rebuild they would have come up **empty**, silently ignoring the backups in Garage. This closes that gap so a bare-metal restore test actually restores all four backed-up clusters.

## Impact

- **No effect on running clusters** — CNPG only reads `bootstrap` at initial cluster creation, so Flux reconcile is a no-op here (same way authelia/lldap already run `recovery` while healthy).
- Takes effect only on a from-scratch rebuild / restore.

## Scope / notes

- Hermod clusters (`api`/`auth`/`bot`) intentionally left as `initdb` — still test data, no backups configured.
- Restore window is ~15 days (ObjectStore `retentionPolicy: 15d`; clean backups began 2026-05-22).
- Validated with `kubeconform` (6 resources, 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)