### PR TITLE
fix(media): pin mousehole 0.4.0 + configure auth password

### DIFF
--- a/kubernetes/apps/media/qbittorrent/app/externalsecret.yaml
+++ b/kubernetes/apps/media/qbittorrent/app/externalsecret.yaml
@@ -16,6 +16,7 @@ spec:
         WIREGUARD_PRESHARED_KEY: "{{ .WIREGUARD_PRESHARED_KEY }}"
         WIREGUARD_ADDRESSES: "{{ .WIREGUARD_ADDRESSES }}"
         SERVER_COUNTRIES: "{{ .SERVER_COUNTRIES }}"
+        MOUSEHOLE_AUTH_PASSWORD: "{{ .MOUSEHOLE_AUTH_PASSWORD }}"
   data:
     - secretKey: WIREGUARD_PRIVATE_KEY
       remoteRef:
@@ -29,3 +30,6 @@ spec:
     - secretKey: SERVER_COUNTRIES
       remoteRef:
         key: "ba4cb37a-3fe4-428b-88c6-b3fd007d0adf"
+    - secretKey: MOUSEHOLE_AUTH_PASSWORD
+      remoteRef:
+        key: "fb1279f4-6280-4e21-83c0-b462000ee6b5"

--- a/kubernetes/apps/media/qbittorrent/app/helmrelease.yaml
+++ b/kubernetes/apps/media/qbittorrent/app/helmrelease.yaml
@@ -95,9 +95,14 @@ spec:
             dependsOn: gluetun
             image:
               repository: tmmrtn/mousehole
-              tag: latest
+              tag: 0.4.0
             env:
               TZ: America/Chicago
+              MOUSEHOLE_AUTH_PASSWORD:
+                valueFrom:
+                  secretKeyRef:
+                    name: qbittorrent-secret
+                    key: MOUSEHOLE_AUTH_PASSWORD
             ports:
               - containerPort: 5010
             probes:


### PR DESCRIPTION
## What broke
After merging #336 (qbittorrent 5.2.0 → 5.2.1), the qbittorrent pod went `2/3 CrashLoopBackOff`. The `app` and `gluetun` containers are healthy; **mousehole** crash-loops.

## Root cause
mousehole used the unpinned `tmmrtn/mousehole:latest` tag. Restarting the pod (from the qbit bump) re-pulled `:latest`, which had rolled to **v0.4.0**. v0.4.0 introduced **mandatory auth** and refuses to start otherwise:

```
error: Mousehole authentication is not configured. Set MOUSEHOLE_AUTH_PASSWORD
and/or MOUSEHOLE_AUTH_TOKEN, or set MOUSEHOLE_INSECURE_ALLOW_NO_AUTH=true to opt out.
```

The previous working copy was a pre-0.4.0 build (`0.3.1`).

## Fix
- **Pin** `tmmrtn/mousehole` to `0.4.0` so `:latest` can't silently break it again.
- Inject `MOUSEHOLE_AUTH_PASSWORD` into the mousehole container via the existing `qbittorrent-secret` ExternalSecret, sourced from Bitwarden item `fb1279f4-6280-4e21-83c0-b462000ee6b5`.

## Verify after merge
```
kubectl rollout status -n media deploy/qbittorrent
kubectl logs -n media -l app.kubernetes.io/name=qbittorrent -c mousehole --tail=20
# expect: started clean, no "authentication is not configured", pod 3/3 Ready
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)