### PR TITLE
fix(media): set mousehole host/origin allowlist for reverse-proxy access

### DIFF
--- a/kubernetes/apps/media/qbittorrent/app/helmrelease.yaml
+++ b/kubernetes/apps/media/qbittorrent/app/helmrelease.yaml
@@ -98,6 +98,8 @@ spec:
               tag: 0.4.0
             env:
               TZ: America/Chicago
+              MOUSEHOLE_ALLOWED_HOSTS: "mousehole.${SECRET_DOMAIN}"
+              MOUSEHOLE_ALLOWED_ORIGINS: "https://mousehole.${SECRET_DOMAIN}"
               MOUSEHOLE_AUTH_PASSWORD:
                 valueFrom:
                   secretKeyRef:


### PR DESCRIPTION
## Why
Follow-up to #369. mousehole **v0.4.0** added Host/Origin validation as part of its security bundle (along with the mandatory auth that #369 handled). `MOUSEHOLE_ALLOWED_HOSTS` defaults to `localhost,127.0.0.1,[::1]`, so requests reaching mousehole through envoy at `mousehole.${SECRET_DOMAIN}` are rejected with a Host-header error.

Symptom: the **web UI is unreachable** through the proxy. The MAM IP-updater (outbound) and the liveness probe (health endpoints are exempt from the allowlist) both keep working, so the pod stays Ready — masking the UI breakage.

## Fix
Allowlist the proxied hostname per the upstream [security guide](https://github.com/t-mart/mousehole/blob/master/docs/security-guide.md) reverse-proxy recipe:
- `MOUSEHOLE_ALLOWED_HOSTS: mousehole.${SECRET_DOMAIN}`
- `MOUSEHOLE_ALLOWED_ORIGINS: https://mousehole.${SECRET_DOMAIN}`

## Verify after merge
Load `https://mousehole.${SECRET_DOMAIN}` — login page renders, dashboard WebSocket connects, no Host/Origin rejection in `kubectl logs -n media -l app.kubernetes.io/name=qbittorrent -c mousehole`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)