### PR TITLE
fix(media): make mousehole liveness probe TCP-only

### DIFF
--- a/kubernetes/apps/media/qbittorrent/app/helmrelease.yaml
+++ b/kubernetes/apps/media/qbittorrent/app/helmrelease.yaml
@@ -108,15 +108,16 @@ spec:
             ports:
               - containerPort: 5010
             probes:
-              liveness: &mouseholeProbes
+              # liveness is TCP-only: /ok and /health both report MAM
+              # reachability (isOnline), so an HTTP probe restarts the
+              # container on every VPN/MAM blip. TCP only trips on real death.
+              liveness:
                 enabled: true
                 custom: true
                 spec:
-                  httpGet:
-                    path: /ok
+                  tcpSocket:
                     port: 5010
                   periodSeconds: 30
-                  timeoutSeconds: 5
                   failureThreshold: 5
               readiness:
                 enabled: false


### PR DESCRIPTION
## Why
Follow-up to #369/#370. mousehole has been restarting ~11×/day. The events show the cause:

```
Warning  Unhealthy  Liveness probe failed: HTTP probe failed with statuscode: 503
```

mousehole's `/ok` (and `/health`) report **MAM reachability** (`isOnline`), not process health. So whenever the gluetun VPN tunnel reconnects or MAM is briefly unreachable, the endpoint returns 503, the liveness probe trips after ~2.5 min (failureThreshold 5 × periodSeconds 30), and Kubernetes restarts the container — for a condition a restart can't fix.

## Fix
Switch liveness to a `tcpSocket` check on 5010 ("is the server accepting connections"):
- Immune to MAM/VPN state — only trips on actual process death.
- Immune to endpoint renames (`/ok` is already deprecated upstream).
- Readiness stays disabled (making it MAM-dependent would hide the UI exactly when you need it to re-paste the cookie).

Also drops an unused `&mouseholeProbes` YAML anchor.

## Verify after merge
```
kubectl rollout status -n media deploy/qbittorrent
# restart count should stop climbing over subsequent VPN reconnects:
kubectl get pod -n media -l app.kubernetes.io/name=qbittorrent \
  -o jsonpath='{range .status.containerStatuses[?(@.name=="mousehole")]}{.restartCount}{"\n"}{end}'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)