### PR TITLE
feat(elli): enable RTX 3080 GPU + local LLM stack for HA voice eval

### DIFF
--- a/docs/elli-gpu-llm.md
+++ b/docs/elli-gpu-llm.md
@@ -1,0 +1,205 @@
+# elli GPU + local LLM (Home Assistant voice) — runbook
+
+Goal: bring elli's RTX 3080 10GB online under Talos/K8s, serve a local LLM via
+Ollama, and run an automated, reproducible A/B (**Gemma 4 E4B** vs **Qwen3 8B**)
+for Home Assistant Assist tool-calling — *before* wiring real voice or rebuilding
+HA. Whisper/Piper (voice) is deferred; the eval below does not need them.
+
+The 3080 is already physically installed and powered in elli, so this is a config
+change, not a hardware change.
+
+## What this branch adds
+
+| Change | File |
+|---|---|
+| elli gets an NVIDIA-enabled install image + loads the nvidia kernel modules + `nvidia.com/gpu.present` label | `talos/nodes/elli.yaml.j2` |
+| Documents elli's 4-extension factory schematic | `talos/schematic.yaml.j2` |
+| NVIDIA device plugin (RuntimeClass + time-slicing + HelmRelease) | `kubernetes/apps/kube-system/nvidia-device-plugin/` |
+| Ollama (GPU, app-template) | `kubernetes/apps/home-automation/ollama/` |
+| Wires both into their namespace kustomizations | `.../kube-system/kustomization.yaml`, `.../home-automation/kustomization.yaml` |
+
+---
+
+## Phase 1 — Bring the GPU online (Talos)
+
+Run from a machine with Bitwarden Secrets access (`bws`), since `task talos:*`
+needs the templated secret env. **Driver/extension installs require a node
+upgrade + reboot.**
+
+1. **Build the schematic.** At <https://factory.talos.dev>, for the current
+   `talos/talenv.yaml` Talos version (amd64 / metal), select these FOUR extensions:
+   - `siderolabs/i915`
+   - `siderolabs/intel-ucode`
+   - `siderolabs/nvidia-open-gpu-kernel-modules-production`  ← open modules are correct for Ampere
+   - `siderolabs/nvidia-container-toolkit-production`
+
+   Copy the returned **schematic ID**.
+
+2. **Paste the ID** into `talos/nodes/elli.yaml.j2` →
+   `machine.install.image` (replace `REPLACE_WITH_ELLI_SCHEMATIC_ID`).
+
+3. **Upgrade elli to the NVIDIA image** (installs the extensions, reboots):
+   ```bash
+   bws run -- task talos:upgrade-node IP=192.168.100.30
+   ```
+   The task pulls the install image straight from elli's rendered config, so it
+   uses the new schematic automatically.
+
+4. **Apply the machine config** (loads the kernel modules + the GPU node label):
+   ```bash
+   bws run -- task talos:apply-node IP=192.168.100.30
+   ```
+
+5. **Verify the driver loaded:**
+   ```bash
+   talosctl -n 192.168.100.30 get extensions          # both nvidia extensions listed
+   talosctl -n 192.168.100.30 read /proc/driver/nvidia/version
+   talosctl -n 192.168.100.30 read /proc/modules | grep nvidia
+   ```
+
+> Ordering matters: upgrade (gets the extension image) **then** apply (loads the
+> modules). Loading `nvidia` modules before the extension image is present fails.
+
+---
+
+## Phase 2 — Expose the GPU to Kubernetes (Flux)
+
+This is pure GitOps — no Talos secrets. Merge/push this branch, then Flux
+reconciles. node-feature-discovery already whitelists PCI class `03`, so it will
+label elli `feature.node.kubernetes.io/pci-10de.present=true`, which the device
+plugin's default affinity targets.
+
+```bash
+flux reconcile kustomization cluster-apps --with-source   # or wait for the interval
+kubectl -n kube-system get ds nvidia-device-plugin
+```
+
+**Verify the node advertises the GPU** (time-slicing → 4):
+```bash
+kubectl get node elli -o jsonpath='{.status.allocatable.nvidia\.com/gpu}{"\n"}'   # -> 4
+```
+
+**Smoke-test with nvidia-smi:**
+```bash
+kubectl run nvidia-smi --rm -it --restart=Never \
+  --image=nvidia/cuda:12.6.0-base-ubuntu22.04 \
+  --overrides='{"spec":{"runtimeClassName":"nvidia","containers":[{"name":"nvidia-smi","image":"nvidia/cuda:12.6.0-base-ubuntu22.04","command":["nvidia-smi"],"resources":{"limits":{"nvidia.com/gpu":1}}}]}}'
+```
+You should see the RTX 3080 in the table.
+
+> **If the GPU is not visible to pods (Talos v1.13 CDI gotcha):** the most likely
+> cause is the CDI hook path. Uncomment the `postRenderers` block in
+> `nvidia-device-plugin/helmrelease.yaml` (it points the hook at
+> `/usr/local/bin/nvidia-cdi-hook`, where Talos puts extension binaries), confirm
+> the container name matches, and `flux reconcile hr nvidia-device-plugin -n kube-system`.
+
+---
+
+## Phase 3 — Pull the models
+
+Ollama lives at `home-automation/ollama` (Service `ollama:11434`).
+
+```bash
+kubectl -n home-automation exec deploy/ollama -- ollama pull gemma4:e4b
+kubectl -n home-automation exec deploy/ollama -- ollama pull qwen3:8b
+kubectl -n home-automation exec deploy/ollama -- ollama list
+```
+
+> Confirm exact tags against the Ollama registry — QAT variants may be tagged e.g.
+> `gemma4:e4b-it-qat`. Prefer the QAT int4 build for the 3080. Both models +
+> headroom fit the 10GB; `OLLAMA_KEEP_ALIVE=-1` keeps the active one resident.
+
+---
+
+## Phase 4 — Raw performance gate (~15 min, near-free)
+
+```bash
+# generation tok/s + prompt-eval (TTFT proxy)
+kubectl -n home-automation exec -it deploy/ollama -- ollama run --verbose qwen3:8b "Say hi in one word."
+kubectl -n home-automation exec -it deploy/ollama -- ollama run --verbose gemma4:e4b "Say hi in one word."
+# confirm 100% GPU residency (any CPU spill tanks throughput)
+kubectl -n home-automation exec deploy/ollama -- ollama ps
+```
+Want comfortably >20–30 tok/s and `100% GPU`. E4B should be faster (smaller) —
+a real tie-breaker if accuracy is close.
+
+---
+
+## Phase 5 — HA-specific eval — THE DECIDER (~1–2 hrs)
+
+`allenporter/home-assistant-datasets` is purpose-built for HA Assist tool-calling
+and produces the leaderboard the HA blog cites. It spins up a *synthetic* HA, so
+it does **not** need your real (still-being-rebuilt) HA instance.
+
+Published leaderboard for reference (E4B is **not** on it — that's the number this
+run fills in): `qwen3-8b` 82.8% assist / 93.4% assist-mini.
+
+```bash
+# On your workstation, reach in-cluster Ollama:
+kubectl -n home-automation port-forward svc/ollama 11434:11434 &
+
+pip install home-assistant-datasets        # or clone + pip install -e .
+
+# models/qwen3-8b.yaml  (repeat for gemma4-e4b):
+#   model_id: qwen3-8b
+#   domain: ollama
+#   config_entry_data:
+#     url: http://localhost:11434
+#     model: qwen3:8b
+#   config_entry_options:
+#     llm_hass_api: assist
+
+for M in qwen3-8b gemma4-e4b; do
+  pytest home_assistant_datasets/tool/assist/collect \
+    --models=$M --dataset=datasets/assist/ --model_output_dir=reports/assist/local
+done
+pytest home_assistant_datasets/tool/assist/eval --model_output_dir=reports/assist/local
+# repeat both steps with --dataset=datasets/assist-mini/
+```
+
+Decision criteria:
+- **assist-mini ≥ ~93% and assist ≥ ~80%** keeps you in the leaderboard band.
+  Well below the published Qwen3-8B numbers ⇒ suspect a quant or chat-template
+  problem, not the model.
+- **Read the per-task wins/losses**, not just the %. For HA, *consistent correct
+  entity targeting and zero hallucinated tool calls* matter more than a point or
+  two — a model that occasionally actuates the wrong device is worse than its score.
+- Use the native-Ollama path (above). Do **not** route tool-calling through
+  Ollama's `/v1` OpenAI shim — it's the documented-unreliable path and would
+  unfairly penalize whichever model goes through it.
+
+Pick the winner; keep the other as a configured fallback (no hardware cost — both
+fit alongside Whisper later).
+
+---
+
+## Phase 6 — Live replay on your real home (DEFERRED until HA is rebuilt)
+
+Synthetic homes can't test your real entity aliases/areas. Once HA is back:
+configure both models as conversation agents and loop ~20–30 of *your* commands
+through `conversation.process` per `agent_id`, diffing responses + resulting
+entity state. Threshold: zero wrong-device actions on your top commands.
+
+---
+
+## Next phase (post-decision) — voice stack
+
+Not needed for the eval. When wiring real voice:
+- `wyoming-whisper-gpu` (STT, GPU — stock `rhasspy/wyoming-whisper` is CPU-only;
+  use a GPU build) + `wyoming-piper` (TTS, CPU). Both co-schedule on the 3080 via
+  the time-slicing slots already configured here.
+- HA Assist: Ollama conversation agent, expose <25 entities, enable "Prefer
+  handling commands locally".
+- Meal-planning automation is a *separate*, cloud-LLM workflow (Mealie + weekly
+  plan) and does not use this GPU.
+
+## Troubleshooting quick hits
+
+- **Pod stuck `CreateContainerError` / no GPU** → Talos v1.13 CDI hook path; see
+  the postRenderer note in `nvidia-device-plugin/helmrelease.yaml`.
+- **`nvidia.com/gpu` is 0** → NFD hasn't labeled elli (driver not loaded — recheck
+  Phase 1 verify) or the device-plugin DaemonSet isn't scheduled.
+- **Ollama CPU-only / slow** → `ollama ps` not `100% GPU`; model too big for free
+  VRAM, or `runtimeClassName: nvidia` not applied.
+- **Schematic/driver mismatch after a Talos upgrade** → rebuild the schematic at
+  factory.talos.dev for the new Talos version and re-run Phase 1.

--- a/kubernetes/apps/home-automation/kustomization.yaml
+++ b/kubernetes/apps/home-automation/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
   - ./home-assistant/ks.yaml
   - ./zigbee2mqtt/ks.yaml
   - ./esphome/ks.yaml
+  - ./ollama/ks.yaml

--- a/kubernetes/apps/home-automation/ollama/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/ollama/app/helmrelease.yaml
@@ -1,0 +1,92 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: ollama
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 1h
+  values:
+    controllers:
+      ollama:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: docker.io/ollama/ollama
+              tag: 0.30.6
+            env:
+              TZ: America/Chicago
+              OLLAMA_HOST: 0.0.0.0:11434
+              # Keep the model resident in VRAM between requests (no reload
+              # latency on every Assist call). -1 = never evict.
+              OLLAMA_KEEP_ALIVE: "-1"
+              # Run as a non-root user; point HOME + model store at the PVC.
+              HOME: /data
+              OLLAMA_MODELS: /data/models
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: &port 11434
+                  initialDelaySeconds: 10
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              readiness: *probes
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: *port
+                  initialDelaySeconds: 5
+                  periodSeconds: 5
+                  failureThreshold: 60
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 200m
+                memory: 2Gi
+              limits:
+                # One time-sliced slot on elli's RTX 3080. Forces scheduling
+                # onto the GPU node; request is auto-set equal to the limit.
+                nvidia.com/gpu: 1
+    defaultPodOptions:
+      # Run under the containerd "nvidia" runtime (Talos toolkit extension).
+      runtimeClassName: nvidia
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+    service:
+      app:
+        controller: ollama
+        ports:
+          http:
+            primary: true
+            port: *port
+    persistence:
+      data:
+        type: persistentVolumeClaim
+        accessMode: ReadWriteOnce
+        size: 50Gi
+        storageClass: ceph-block
+        globalMounts:
+          - path: /data
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/home-automation/ollama/app/kustomization.yaml
+++ b/kubernetes/apps/home-automation/ollama/app/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/apps/home-automation/ollama/ks.yaml
+++ b/kubernetes/apps/home-automation/ollama/ks.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app ollama
+  namespace: &namespace home-automation
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+    - name: nvidia-device-plugin
+      namespace: kube-system
+  interval: 1h
+  path: ./kubernetes/apps/home-automation/ollama/app
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false

--- a/kubernetes/apps/kube-system/kustomization.yaml
+++ b/kubernetes/apps/kube-system/kustomization.yaml
@@ -14,5 +14,6 @@ resources:
   - ./reflector/ks.yaml
   - ./netboot/ks.yaml
   - ./intel-device-plugin/ks.yaml
+  - ./nvidia-device-plugin/ks.yaml
   - ./node-feature-discovery/ks.yaml
   - ./snapshot-controller/ks.yaml

--- a/kubernetes/apps/kube-system/nvidia-device-plugin/config.yaml
+++ b/kubernetes/apps/kube-system/nvidia-device-plugin/config.yaml
@@ -1,0 +1,23 @@
+---
+# Time-slicing: one physical 3080 (no MIG on consumer Ampere) is advertised as
+# 4x nvidia.com/gpu so Ollama and (later) wyoming-whisper can co-schedule on it.
+# CAVEAT: replicas share the SAME 10GB VRAM — no memory isolation. Size the
+# resident models to fit together (e.g. an 8B Q4 LLM + a small Whisper).
+# For the eval phase only one model runs at a time, so this is purely
+# forward-looking; lower `replicas` to 1 to disable sharing.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nvidia-device-plugin-configs
+data:
+  default: |-
+    version: v1
+    flags:
+      migStrategy: none
+    sharing:
+      timeSlicing:
+        renameByDefault: false
+        failRequestsGreaterThanOne: false
+        resources:
+          - name: nvidia.com/gpu
+            replicas: 4

--- a/kubernetes/apps/kube-system/nvidia-device-plugin/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/nvidia-device-plugin/helmrelease.yaml
@@ -1,0 +1,54 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: nvidia-device-plugin
+spec:
+  interval: 1h
+  chart:
+    spec:
+      chart: nvidia-device-plugin
+      version: 0.19.2
+      reconcileStrategy: ChartVersion
+      sourceRef:
+        kind: HelmRepository
+        name: nvidia-device-plugin
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    # Pods that request nvidia.com/gpu must run under the "nvidia" containerd
+    # runtime registered by the Talos nvidia-container-toolkit extension.
+    runtimeClassName: nvidia
+    # Time-slicing config (see config.yaml). One 3080 -> 4x nvidia.com/gpu.
+    config:
+      name: nvidia-device-plugin-configs
+      default: default
+    # The chart's default affinity already pins the DaemonSet to nodes carrying
+    # the NFD label feature.node.kubernetes.io/pci-10de.present=true (NVIDIA),
+    # which node-feature-discovery sets on elli once the 3080 is visible.
+  # --- Talos v1.13 CDI hook path fix --------------------------------------
+  # Talos v1.13 runs containerd with CDI enabled. If the nvidia-smi test pod
+  # cannot see the GPU (CreateContainerError / missing nvidia-cdi-hook), the
+  # plugin is looking for the hook in the wrong place — Talos installs extension
+  # binaries under /usr/local/bin. Uncomment the postRenderer below to point it
+  # there, then `flux reconcile hr nvidia-device-plugin -n kube-system`.
+  # Verify the container name first: kubectl -n kube-system get ds \
+  #   nvidia-device-plugin -o jsonpath='{.spec.template.spec.containers[0].name}'
+  #
+  # postRenderers:
+  #   - kustomize:
+  #       patches:
+  #         - target:
+  #             kind: DaemonSet
+  #             name: nvidia-device-plugin
+  #           patch: |
+  #             - op: add
+  #               path: /spec/template/spec/containers/0/env/-
+  #               value:
+  #                 name: NVIDIA_CDI_HOOK_PATH
+  #                 value: /usr/local/bin/nvidia-cdi-hook

--- a/kubernetes/apps/kube-system/nvidia-device-plugin/helmrepository.yaml
+++ b/kubernetes/apps/kube-system/nvidia-device-plugin/helmrepository.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: nvidia-device-plugin
+spec:
+  interval: 1h
+  url: https://nvidia.github.io/k8s-device-plugin

--- a/kubernetes/apps/kube-system/nvidia-device-plugin/ks.yaml
+++ b/kubernetes/apps/kube-system/nvidia-device-plugin/ks.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: nvidia-device-plugin
+spec:
+  dependsOn:
+    - name: node-feature-discovery
+  interval: 1h
+  path: ./kubernetes/apps/kube-system/nvidia-device-plugin
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: kube-system
+  wait: false

--- a/kubernetes/apps/kube-system/nvidia-device-plugin/kustomization.yaml
+++ b/kubernetes/apps/kube-system/nvidia-device-plugin/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./runtimeclass.yaml
+  - ./config.yaml
+  - ./helmrepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/kube-system/nvidia-device-plugin/runtimeclass.yaml
+++ b/kubernetes/apps/kube-system/nvidia-device-plugin/runtimeclass.yaml
@@ -1,0 +1,8 @@
+---
+# The nvidia-container-toolkit Talos extension registers a containerd runtime
+# named "nvidia". Pods that need the GPU set runtimeClassName: nvidia.
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: nvidia
+handler: nvidia

--- a/talos/nodes/elli.yaml.j2
+++ b/talos/nodes/elli.yaml.j2
@@ -4,8 +4,23 @@ machine:
   install:
     diskSelector:
       model: "Samsung SSD 850"
+    # elli carries an RTX 3080 — it needs a different factory image than the rest
+    # of the cluster (base schematic + the two NVIDIA extensions). Build the
+    # schematic at https://factory.talos.dev with the FOUR extensions documented
+    # in talos/schematic.yaml.j2 ("elli" block), then paste the returned ID below.
+    # Until then this still renders; just don't `upgrade-node` elli with a stale ID.
+    image: factory.talos.dev/installer/e321bc76be3bc9f170a6af44753f216f3ffaaa2874b7a2d055394df2e121ddeb:{{ ENV.TALOS_VERSION }}
+  # Load the NVIDIA kernel modules supplied by the schematic's
+  # nvidia-open-gpu-kernel-modules-production extension (Ampere/RTX 3080).
+  kernel:
+    modules:
+      - name: nvidia
+      - name: nvidia_uvm
+      - name: nvidia_drm
+      - name: nvidia_modeset
   nodeLabels:
     clusterrole: highspeed
+    nvidia.com/gpu.present: "true"
 ---
 apiVersion: v1alpha1
 kind: HostnameConfig

--- a/talos/schematic.yaml.j2
+++ b/talos/schematic.yaml.j2
@@ -13,3 +13,15 @@ customization:
     officialExtensions:
       - siderolabs/i915  # Intel iGPU passthrough for plex/jellyfin/etc.
       - siderolabs/intel-ucode  # Intel CPU microcode updates
+#
+# elli-only schematic (RTX 3080). elli's machine.install.image
+# (talos/nodes/elli.yaml.j2) points at a SEPARATE schematic built from the base
+# extensions above PLUS the two NVIDIA extensions below. Build it at
+# https://factory.talos.dev for the current talenv.yaml Talos version and paste
+# the returned ID into elli.yaml.j2. Both NVIDIA extensions must stay on the same
+# driver branch (-production). Open kernel modules are correct for Ampere.
+#
+#   - siderolabs/i915
+#   - siderolabs/intel-ucode
+#   - siderolabs/nvidia-open-gpu-kernel-modules-production
+#   - siderolabs/nvidia-container-toolkit-production


### PR DESCRIPTION
Brings elli's RTX 3080 10GB online under Talos and serves a local LLM via Ollama to evaluate Home Assistant Assist tool-calling (**Gemma 4 E4B** vs **Qwen3 8B**) before wiring real voice.

## What's here

**Talos (elli)**
- `elli.yaml.j2`: NVIDIA-enabled factory image (schematic `e321bc76` = base extensions + `nvidia-open-gpu-kernel-modules-production` + `nvidia-container-toolkit-production`), loads the 4 nvidia kernel modules, adds a `nvidia.com/gpu.present` node label
- `schematic.yaml.j2`: documents elli's 4-extension build

**Flux apps**
- `kube-system/nvidia-device-plugin/`: RuntimeClass `nvidia`, time-slicing ConfigMap (1 GPU → 4 slots), HelmRelease `0.19.2`
- `home-automation/ollama/`: app-template HelmRelease (GPU limit, `OLLAMA_KEEP_ALIVE=-1`, 50Gi ceph-block PVC, non-root)

**Docs**
- `docs/elli-gpu-llm.md`: end-to-end runbook (Talos bring-up → device plugin → pull models → perf gate → HA-datasets eval → deferred live replay)

## Status

- ✅ Phase 1 (Talos bring-up) applied + verified on elli: schematic matches, NVRM 595.71.05 open driver loaded, all 4 kernel modules Live
- ⏳ Merging this deploys the device plugin + ollama via Flux

## Apply notes / human touchpoints
- Confirm exact Ollama model tags at pull time (e.g. `gemma4:e4b-it-qat`)
- If the `nvidia-smi` test pod can't see the GPU (Talos v1.13 CDI hook path), uncomment the ready `postRenderer` in `nvidia-device-plugin/helmrelease.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)