### PR TITLE
fix(media): retry recyclarr cronjob on transient failure

### DIFF
--- a/kubernetes/apps/media/recyclarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/recyclarr/app/helmrelease.yaml
@@ -14,7 +14,9 @@ spec:
         type: cronjob
         cronjob:
           schedule: "0 5 * * *"
-          backoffLimit: 0
+          # retry transient failures (e.g. DNS blips resolving github.com
+          # for the TRaSH-Guides fetch); recyclarr sync is idempotent
+          backoffLimit: 3
           concurrencyPolicy: Forbid
           successfulJobsHistory: 1
           failedJobsHistory: 1


### PR DESCRIPTION
## Problem
The nightly recyclarr sync has been failing intermittently. Root cause is **not** an upgrade — the image (`8.6.0`) is unchanged. At the 5 AM run, resolving `github.com` for the TRaSH-Guides git fetch timed out; recyclarr deletes its local git cache on that error and the retry's DNS also failed, hard-failing on `FETCH_HEAD`. With `backoffLimit: 0` the Job gets exactly one attempt, so a brief upstream DNS blip = a failed nightly job.

CoreDNS (recently bumped) is ruled out: Corefile is byte-identical, image unchanged, healthy, and a 30/30 DNS burst passed. A manual job run completed cleanly. No 5 AM cluster contention (VolSync at 00/12, kometa at 3, kopia at 3:30).

## Fix
Raise `backoffLimit` from `0` to `3`. With `restartPolicy: Never`, K8s retries failed pods with exponential backoff (~10s/20s/40s), riding through a transient blip. recyclarr sync is idempotent and `concurrencyPolicy: Forbid` still prevents overlap, so retries are safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)