### PR TITLE
fix(rook-ceph): pin ceph daemon to v19.2.4

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -49,6 +49,12 @@ spec:
     toolbox:
       enabled: true
     cephClusterSpec:
+      # Pin daemon image explicitly (chart default for rook 1.19.5 is v19.2.3).
+      # 19.2.4 carries msgr-v2 / MonClient fixes for the recurring ceph-mon
+      # SIGSEGV in the connection-reset path, plus the bluestore data-corruption
+      # patch. Decoupled from the held rook operator 1.20 upgrade (#367).
+      cephVersion:
+        image: quay.io/ceph/ceph:v19.2.4
       cephConfig:
         global:
           bdev_enable_discard: "true" # quote


### PR DESCRIPTION
## Why
The recurring `ceph-mon` SIGSEGV (`HEALTH_WARN: N daemons have recently crashed`) is a **software bug**, not hardware or a bad node:

- Raw segfault (no assert) in the msgr-v2 connection-reset path: `handle_existing_connection → reset_session → buffer::ptr::release` — a connection-reuse use-after-free pattern.
- Recurs ~every 1–2 months on **19.2.3** (Aug, Mar, Apr, May, Jun), in bursts, on whichever mon is in quorum.
- **Smoking gun:** on 2026-03-22 13:16, three mons on three *different physical hosts* (`dvergar-00`, `dvergar-06`, `elli`) crashed within the same 26s window with an **identical stack signature** — hardware can't do that.
- Rook self-heals (rotates the mon) and the data layer is unaffected (PGs stay `active+clean`), but the WARN noise + quorum churn are worth ending.
- No exact upstream tracker / Clyso known-bug entry matches `reset_session` — under-reported, but a known *class* of msgr-v2 memory-safety crash.

## What
Pin the Ceph **daemon** image to **v19.2.4** (released 2026-06-01). The rook-ceph-cluster 1.19.5 chart defaults to v19.2.3, so this sets `cephClusterSpec.cephVersion.image` explicitly.

- 19.2.4 carries msgr-v2 / MonClient fixes in this exact subsystem (*candidate* fix — not a verbatim match, so not guaranteed).
- Independently worth it: 19.2.4 patches the silent OSD data-corruption bug (`bluestore_elastic_shared_blobs`) present in 19.2.0–19.2.3.
- **Decoupled from the held rook operator 1.20 upgrade (#367)** — daemon version is independent; rook 1.19.5 supports any 19.2.x.

## Rollout / risk
Z-stream daemon bump = rolling restart of mons then OSDs, orchestrated by Rook. No expected downtime (3 mons, 5 OSDs, 33 PGs). **Best merged in a window where `ceph -s` can be watched** as daemons step through to HEALTH_OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)