### PR TITLE
feat(mealie): flip mealie-pg bootstrap to recovery

### DIFF
--- a/kubernetes/apps/default/mealie/db/cluster.yaml
+++ b/kubernetes/apps/default/mealie/db/cluster.yaml
@@ -15,13 +15,9 @@ spec:
   resources:
     requests:
       cpu: 50m
-  # First deploy: initdb. After the first successful backup lands in
-  # s3://cnpg/mealie/, switch bootstrap to recovery (source: mealie-pg-v1)
-  # to match the disaster-recovery posture of the other clusters.
   bootstrap:
-    initdb:
-      database: mealie
-      owner: mealie
+    recovery:
+      source: mealie-pg-v1
   plugins:
     - name: barman-cloud.cloudnative-pg.io
       isWALArchiver: true


### PR DESCRIPTION
## Summary

First barman backup (`mealie-pg-20260610064257`) completed in `s3://cnpg/mealie/` — switch `mealie-pg` bootstrap from `initdb` to `recovery` (source `mealie-pg-v1`), matching the disaster-recovery posture of the other CNPG clusters (cnpg-cluster component convention).

No-op for the running cluster (bootstrap only applies on recreation); ensures any future rebuild restores from the object store instead of starting empty.

References #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)