### PR TITLE
fix(mealie): use gemini-flash-latest rolling alias for AI seed

### DIFF
--- a/kubernetes/apps/default/mealie/app/helmrelease.yaml
+++ b/kubernetes/apps/default/mealie/app/helmrelease.yaml
@@ -49,7 +49,7 @@ spec:
               OIDC_AUTO_REDIRECT: "false"
               OIDC_ADMIN_GROUP: admins
               OPENAI_BASE_URL: "https://generativelanguage.googleapis.com/v1beta/openai/"
-              OPENAI_MODEL: gemini-2.5-flash
+              OPENAI_MODEL: gemini-flash-latest
               OPENAI_API_KEY:
                 valueFrom:
                   secretKeyRef:


### PR DESCRIPTION
## Summary

`gemini-2.5-flash` is scheduled for shutdown on **2026-06-17**. Switch the Mealie AI seed to `gemini-flash-latest` — Google's rolling alias on the OpenAI-compat endpoint that tracks the current stable Flash model (verified against the live `/models` list with the deployed key).

Note: in Mealie v3.19 the `OPENAI_*` env vars are import-only seeds (AI providers are managed in-app per group since mealie-recipes/mealie#7650); this keeps the manifest correct for any future fresh bootstrap, and the in-app provider should use the same model name.

References #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)