### PR TITLE
docs(mealie): HA weekly planner package + completed runbook

### DIFF
--- a/docs/mealie-meal-planning.md
+++ b/docs/mealie-meal-planning.md
@@ -20,15 +20,20 @@ meal-driven items go to Hy-Vee/Target.
 
 - URL: `https://recipes.${SECRET_DOMAIN}` (envoy-external)
 - DB: CNPG `mealie-pg` (2 instances, barman → `s3://cnpg/mealie/` on Garage).
-  First deploy bootstraps with `initdb`; a follow-up PR flips to `recovery`
-  after the first backup lands (same convention as the other clusters).
+  Bootstrapped with `initdb` on first deploy; flipped to `recovery` after the
+  first backup landed (#379, same convention as the other clusters).
 - Auth: OIDC against Authelia. `OIDC_ADMIN_GROUP: admins` → LLDAP admins land as
   Mealie admins. `OIDC_AUTO_REDIRECT: false` keeps the local login form as
   break-glass. Optional: create an LLDAP group `mealie` and set
   `OIDC_USER_GROUP: mealie` to gate access.
 - AI: `OPENAI_*` env vars point at Gemini's OpenAI-compat endpoint. Since
-  Mealie v3.19 these only **seed** the provider — manage/verify it afterwards in
-  Admin → Settings → AI Providers.
+  Mealie v3.19 AI providers are managed **per group** in the UI (Group
+  Settings → AI Providers — there is no admin site-settings page for this;
+  upstream PR mealie-recipes/mealie#7650). The env vars are a deprecated
+  import-only seed applied on upgrade — on a fresh install, configure the
+  provider in the group settings: base URL
+  `https://generativelanguage.googleapis.com/v1beta/openai/`, the Gemini API
+  key, model `gemini-flash-latest`.
 
 ## Bitwarden entries (Step 0)
 
@@ -42,14 +47,17 @@ meal-driven items go to Hy-Vee/Target.
 
 1. Log in at `https://recipes.${SECRET_DOMAIN}` via Authelia (admins-group user
    lands as admin).
-2. Admin → AI Providers: confirm the seeded Gemini provider; test with an AI
-   recipe URL import.
-3. Create a `homeassistant` user; generate an API token (profile → API tokens).
+2. Group Settings → AI Providers: configure/confirm the Gemini provider (see
+   above); test with an AI recipe URL or image import.
+3. Generate an API token for HA (Profile → Manage → API Tokens). A dedicated
+   `homeassistant` user is optional — everything the integration touches is
+   household-scoped, so a token from your own account sees the same data; a
+   separate user only buys independent revocation and audit clarity.
 4. Create shopping list(s) and labels `Costco`, `Hy-Vee`, `Target`.
 5. Recipe curation (drives planner quality): tag recipes with effort level
    (`weeknight`/`weekend`), `kid-friendly`, season; fill prep/total times.
 
-## Home Assistant wiring (PR 3 — planner package)
+## Home Assistant wiring (planner package)
 
 Manual integrations (HA UI):
 
@@ -61,23 +69,37 @@ Manual integrations (HA UI):
 3. **Google Generative AI**: same Gemini key; creates the `ai_task` entity —
    set it as preferred AI Task entity in Settings.
 
-Planner package (`/config/packages/mealie_meal_planner.yaml`, via code-server —
-prereq `homeassistant: packages: !include_dir_named packages`):
+The full planner package lives at [`mealie_meal_planner.yaml`](mealie_meal_planner.yaml).
+Copy it to `/config/packages/mealie_meal_planner.yaml` (code-server at
+`home-code.${SECRET_DOMAIN}`), fill the `REPLACE_*` markers, ensure
+`configuration.yaml` has `homeassistant: packages: !include_dir_named
+packages`, then restart HA.
+
+What it contains:
 
 - `script.generate_weekly_meal_plan` — gathers calendar events (next 8 days),
-  weather forecast, Mealie recipes (dinner-tagged), recent plans →
+  weather forecast, the Mealie recipe catalog, last 14 days of plans →
   `ai_task.generate_data` with a JSON schema
   `{days: [{date, meal, recipe_slug, note}], shopping_list: [{item, store}]}`.
   Prompt rules: busy evenings (events 17:00–20:00) get quick/slow-cooker/
-  leftover meals; plan cook-once-eat-twice pairs; tag items by store.
+  leftover meals; plan cook-once-eat-twice pairs; weather-aware meals; tag
+  items by store; no repeats from the last two weeks.
 - `sensor.proposed_meal_plan` — trigger-based template sensor holding the
   proposal for the approval flow.
-- Approval automation — Friday 16:00: generate → actionable phone notification
-  (Approve / Regenerate) → on approve, `mealie.set_mealplan` per day and
-  `todo.add_item` per shopping item.
+- Automations — Friday 16:00 generate → actionable phone notification; Approve
+  writes each day via `mealie.set_mealplan` and each item via `todo.add_item`
+  (with the store in parentheses); Regenerate reruns the script.
 
-**→ Full package YAML lands with PR 3** (entity IDs and the Mealie
-`config_entry_id` get filled in after the integrations above exist).
+Where to find each `REPLACE_*` value (after the integrations exist):
+
+| Marker | Where to find it |
+|---|---|
+| `REPLACE_MEALIE_CONFIG_ENTRY` | Settings → Devices & Services → Mealie → the `config_entry` ID in the page URL (or Download diagnostics → `entry_id`) |
+| `REPLACE_CALENDAR_ENTITIES` | Developer Tools → States, filter `calendar.` — YAML list of the family calendars |
+| `REPLACE_WEATHER_ENTITY` | Developer Tools → States, filter `weather.` (e.g. `weather.forecast_home`) |
+| `REPLACE_AI_TASK_ENTITY` | Developer Tools → States, filter `ai_task.` (from Google Generative AI) |
+| `REPLACE_SHOPPING_TODO` | Developer Tools → States, filter `todo.` — the Mealie shopping list entity |
+| `REPLACE_NOTIFY_SERVICE` | Developer Tools → Actions, search `notify.mobile_app` |
 
 ## Verification
 
@@ -96,9 +118,11 @@ prereq `homeassistant: packages: !include_dir_named packages`):
 - Mealie image historically used root entrypoint + PUID/PGID; manifest runs it
   as `runAsNonRoot: 1000`. If it crash-loops on permissions, drop
   `runAsNonRoot` and set `PUID`/`PGID: "1000"` instead.
-- `OPENAI_MODEL: gemini-2.5-flash` — Google deprecates models on the
-  OpenAI-compat endpoint periodically; the in-app AI provider setting is
-  authoritative after first boot.
+- Google deprecates models on the OpenAI-compat endpoint periodically
+  (`gemini-2.5-flash` retires 2026-06-17). Use the `gemini-flash-latest`
+  rolling alias — it tracks the newest stable Flash release (currently
+  3.5) — both in the env seed and the in-app provider, which is the
+  authoritative setting.
 
 ## Future phases (tracking issues)
 

--- a/docs/mealie_meal_planner.yaml
+++ b/docs/mealie_meal_planner.yaml
@@ -1,0 +1,200 @@
+# /config/packages/mealie_meal_planner.yaml
+# Prereq in configuration.yaml:
+#   homeassistant:
+#     packages: !include_dir_named packages
+#
+# REPLACE_ME markers (filled after integrations exist):
+#   REPLACE_MEALIE_CONFIG_ENTRY  — Mealie integration config_entry_id
+#   REPLACE_CALENDAR_ENTITIES    — family calendar entities, e.g. [calendar.tyler, calendar.spouse]
+#   REPLACE_WEATHER_ENTITY       — e.g. weather.forecast_home
+#   REPLACE_AI_TASK_ENTITY       — e.g. ai_task.google_ai_task
+#   REPLACE_SHOPPING_TODO        — e.g. todo.mealie_shopping_list
+#   REPLACE_NOTIFY_SERVICE       — e.g. notify.mobile_app_tylers_phone
+
+template:
+  - triggers:
+      - trigger: event
+        event_type: meal_plan_proposed
+    sensor:
+      - name: Proposed meal plan
+        unique_id: proposed_meal_plan
+        state: "{{ trigger.event.data.generated_at }}"
+        attributes:
+          days: "{{ trigger.event.data.days }}"
+          shopping_list: "{{ trigger.event.data.shopping_list }}"
+
+script:
+  generate_weekly_meal_plan:
+    alias: Generate weekly meal plan
+    mode: restart
+    sequence:
+      - alias: Family calendar events, next 8 days
+        action: calendar.get_events
+        target:
+          entity_id: REPLACE_CALENDAR_ENTITIES
+        data:
+          start_date_time: "{{ today_at() }}"
+          duration:
+            days: 8
+        response_variable: events
+      - alias: Daily forecast
+        action: weather.get_forecasts
+        target:
+          entity_id: REPLACE_WEATHER_ENTITY
+        data:
+          type: daily
+        response_variable: forecast
+      - alias: Recipe catalog (slug + name)
+        action: mealie.get_recipes
+        data:
+          config_entry_id: REPLACE_MEALIE_CONFIG_ENTRY
+        response_variable: catalog
+      - alias: Last 2 weeks of dinners (avoid repeats)
+        action: mealie.get_mealplan
+        data:
+          config_entry_id: REPLACE_MEALIE_CONFIG_ENTRY
+          start_date: "{{ (now() - timedelta(days=14)).date() }}"
+          end_date: "{{ now().date() }}"
+        response_variable: recent
+      - alias: Ask Gemini for the plan
+        action: ai_task.generate_data
+        data:
+          entity_id: REPLACE_AI_TASK_ENTITY
+          task_name: weekly_meal_plan
+          instructions: >-
+            You are planning family dinners for the 7 days starting
+            {{ now().date() }}. Rules:
+
+            - Busy evenings (any calendar event overlapping 17:00-20:00) get a
+              quick (<30 min), slow-cooker, or leftovers meal.
+            - Plan deliberate cook-once-eat-twice pairs: a larger weekend or
+              free-evening cook followed by a leftovers night on the busiest
+              evening.
+            - Use the weather: grilling/lighter meals on warm dry days, soups,
+              stews and oven meals on cold or rainy days.
+            - Prefer recipes from the catalog below; return their exact slug in
+              recipe_slug. If you propose something not in the catalog, leave
+              recipe_slug empty and describe the meal in note.
+            - Do not repeat anything from the recent dinners list.
+            - Produce a consolidated shopping list for the week. Tag each item
+              with the store it should come from: Hy-Vee or Target for
+              meal-driven items (groceries vs household goods), Costco only for
+              bulk staples.
+
+            Calendar events:
+            {{ events | tojson }}
+
+            Daily forecast:
+            {{ forecast | tojson }}
+
+            Recipe catalog (slug — name):
+            {% for r in catalog.recipes %}
+            {{ r.slug }} — {{ r.name }}
+            {% endfor %}
+
+            Recent dinners (avoid):
+            {{ recent.mealplan | map(attribute='recipe.name', default='') | select('ne', '') | list | tojson }}
+          structure:
+            days:
+              description: >-
+                One entry per day: date (YYYY-MM-DD), meal (short title),
+                recipe_slug (exact slug from catalog or empty string), note
+                (why this fits the day, or the full description for
+                non-catalog meals).
+              required: true
+              selector:
+                object:
+            shopping_list:
+              description: >-
+                Consolidated list. Each entry: item (string), store (one of
+                Costco, Hy-Vee, Target).
+              required: true
+              selector:
+                object:
+        response_variable: plan
+      - alias: Publish proposal for the approval flow
+        event: meal_plan_proposed
+        event_data:
+          generated_at: "{{ now().isoformat() }}"
+          days: "{{ plan.data.days }}"
+          shopping_list: "{{ plan.data.shopping_list }}"
+      - alias: Ask for approval
+        action: REPLACE_NOTIFY_SERVICE
+        data:
+          title: "Meal plan for week of {{ now().date() }}"
+          message: >-
+            {% for d in plan.data.days %}
+            {{ d.date }}: {{ d.meal }}
+            {% endfor %}
+          data:
+            actions:
+              - action: MEAL_PLAN_APPROVE
+                title: Approve
+              - action: MEAL_PLAN_REDO
+                title: Regenerate
+
+automation:
+  - alias: Weekly meal plan generation
+    id: weekly_meal_plan_generation
+    triggers:
+      - trigger: time
+        at: "16:00:00"
+    conditions:
+      - condition: time
+        weekday: [fri]
+    actions:
+      - action: script.generate_weekly_meal_plan
+
+  - alias: Meal plan approved
+    id: meal_plan_approved
+    triggers:
+      - trigger: event
+        event_type: mobile_app_notification_action
+        event_data:
+          action: MEAL_PLAN_APPROVE
+    actions:
+      - alias: Write each day into Mealie
+        repeat:
+          for_each: "{{ state_attr('sensor.proposed_meal_plan', 'days') }}"
+          sequence:
+            - choose:
+                - conditions: "{{ repeat.item.recipe_slug | default('') != '' }}"
+                  sequence:
+                    - action: mealie.set_mealplan
+                      data:
+                        config_entry_id: REPLACE_MEALIE_CONFIG_ENTRY
+                        date: "{{ repeat.item.date }}"
+                        entry_type: dinner
+                        recipe_id: "{{ repeat.item.recipe_slug }}"
+              default:
+                - action: mealie.set_mealplan
+                  data:
+                    config_entry_id: REPLACE_MEALIE_CONFIG_ENTRY
+                    date: "{{ repeat.item.date }}"
+                    entry_type: dinner
+                    note_title: "{{ repeat.item.meal }}"
+                    note_text: "{{ repeat.item.note | default('') }}"
+      - alias: Add shopping items (store in parentheses)
+        repeat:
+          for_each: "{{ state_attr('sensor.proposed_meal_plan', 'shopping_list') }}"
+          sequence:
+            - action: todo.add_item
+              target:
+                entity_id: REPLACE_SHOPPING_TODO
+              data:
+                item: "{{ repeat.item.item }} ({{ repeat.item.store }})"
+      - action: REPLACE_NOTIFY_SERVICE
+        data:
+          message: "Meal plan committed to Mealie — shopping list updated."
+
+  - alias: Meal plan regenerate
+    id: meal_plan_regenerate
+    triggers:
+      - trigger: event
+        event_type: mobile_app_notification_action
+        event_data:
+          action: MEAL_PLAN_REDO
+    actions:
+      - action: script.turn_on
+        target:
+          entity_id: script.generate_weekly_meal_plan


### PR DESCRIPTION
## Summary
Phase C of the meal-planning stack (PR 3 of 3): the complete Home Assistant planner package and the finished runbook, corrected from real-deploy findings.

- **`docs/mealie_meal_planner.yaml`** — drop-in HA package for `/config/packages/`:
  - `script.generate_weekly_meal_plan`: family calendars (8 days) + daily forecast + Mealie recipe catalog + last 14 days of plans → `ai_task.generate_data` (Gemini, structured output `{days, shopping_list}`)
  - trigger-based `sensor.proposed_meal_plan` holds the proposal
  - automations: Friday 16:00 generate → actionable phone notification; **Approve** writes each day via `mealie.set_mealplan` and each item via `todo.add_item` (store in parentheses); **Regenerate** reruns
  - six `REPLACE_*` markers filled in after the HA integrations exist (lookup table in the runbook)
- **`docs/mealie-meal-planning.md`** corrections:
  - AI providers are **per-group** settings since v3.19 (mealie-recipes/mealie#7650), not admin site-settings; `OPENAI_*` env vars are an import-only seed
  - dedicated `homeassistant` user not required — any household member's API token sees the same household-scoped data
  - `gemini-flash-latest` rolling alias guidance (2.5-flash retires 2026-06-17; alias currently resolves to 3.5-flash)
  - HA wiring section now references the package file + ID lookup table

Refs #182 (HA k8s migration — does not close it). Docs-only; no cluster changes.

## Test plan
- [x] package YAML parses (`yq`) with expected `template`/`script`/`automation` keys
- [ ] after HA integrations exist: fill markers, copy to `/config/packages/`, restart HA, run `script.generate_weekly_meal_plan`, approve from phone, verify plan in Mealie calendar + items on shopping list

🤖 Generated with [Claude Code](https://claude.com/claude-code)