### PR TITLE
fix(rook-ceph): pin mons off elli (failing 850 EVO corrupting mon db)

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -82,6 +82,17 @@ spec:
         addressRanges:
           cluster:
             - "10.10.10.0/24"
+      placement:
+        # Temporary workaround — remove once elli's system SSD is replaced. See #424.
+        mon:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: kubernetes.io/hostname
+                      operator: NotIn
+                      values:
+                        - elli
       storage:
         useAllNodes: true
         useAllDevices: false


### PR DESCRIPTION
Pins Ceph mons off **elli** via `cephClusterSpec.placement.mon` nodeAffinity (`kubernetes.io/hostname NotIn [elli]`), because elli's system SSD is producing silent on-disk corruption that crash-loops any mon scheduled there. Previously `placement` was empty, so any dvergar-mon failover could land a new mon on elli → recurrence.

Full hardware diagnosis, SMART/RAM findings, and the revert checklist live in #424.

## Safety
- elli holds **no OSD** (data SSDs are device-filtered), so only the mon store was ever exposed — Ceph **data pools were never at risk**.
- **Non-disruptive:** all 3 current mons (`o,r,t`) already run on dvergar-00/02/05, which satisfy the new affinity. No mon eviction on apply.
- Cluster is currently HEALTH_OK (recent crashes archived to re-arm the `CephDaemonCrash` alert).

## Revert
Temporary workaround. Remove the `placement.mon` block once elli's SSD is replaced — tracked in #424.

🤖 Generated with [Claude Code](https://claude.com/claude-code)