### PR TITLE
feat(talos): add mgmt0.30 IoT VLAN interface on all nodes

### DIFF
--- a/talos/nodes/dvergar-00.yaml.j2
+++ b/talos/nodes/dvergar-00.yaml.j2
@@ -40,6 +40,12 @@ parent: mgmt0
 vlanID: 70
 ---
 apiVersion: v1alpha1
+kind: VLANConfig
+name: mgmt0.30
+parent: mgmt0
+vlanID: 30
+---
+apiVersion: v1alpha1
 kind: LinkAliasConfig
 name: mgmt0
 selector:

--- a/talos/nodes/dvergar-01.yaml.j2
+++ b/talos/nodes/dvergar-01.yaml.j2
@@ -40,6 +40,12 @@ parent: mgmt0
 vlanID: 70
 ---
 apiVersion: v1alpha1
+kind: VLANConfig
+name: mgmt0.30
+parent: mgmt0
+vlanID: 30
+---
+apiVersion: v1alpha1
 kind: LinkAliasConfig
 name: mgmt0
 selector:

--- a/talos/nodes/dvergar-02.yaml.j2
+++ b/talos/nodes/dvergar-02.yaml.j2
@@ -40,6 +40,12 @@ parent: mgmt0
 vlanID: 70
 ---
 apiVersion: v1alpha1
+kind: VLANConfig
+name: mgmt0.30
+parent: mgmt0
+vlanID: 30
+---
+apiVersion: v1alpha1
 kind: LinkAliasConfig
 name: mgmt0
 selector:

--- a/talos/nodes/dvergar-03.yaml.j2
+++ b/talos/nodes/dvergar-03.yaml.j2
@@ -33,6 +33,12 @@ parent: mgmt0
 vlanID: 70
 ---
 apiVersion: v1alpha1
+kind: VLANConfig
+name: mgmt0.30
+parent: mgmt0
+vlanID: 30
+---
+apiVersion: v1alpha1
 kind: LinkAliasConfig
 name: mgmt0
 selector:

--- a/talos/nodes/dvergar-04.yaml.j2
+++ b/talos/nodes/dvergar-04.yaml.j2
@@ -26,6 +26,12 @@ parent: mgmt0
 vlanID: 70
 ---
 apiVersion: v1alpha1
+kind: VLANConfig
+name: mgmt0.30
+parent: mgmt0
+vlanID: 30
+---
+apiVersion: v1alpha1
 kind: LinkAliasConfig
 name: mgmt0
 selector:

--- a/talos/nodes/dvergar-05.yaml.j2
+++ b/talos/nodes/dvergar-05.yaml.j2
@@ -35,6 +35,12 @@ parent: mgmt0
 vlanID: 70
 ---
 apiVersion: v1alpha1
+kind: VLANConfig
+name: mgmt0.30
+parent: mgmt0
+vlanID: 30
+---
+apiVersion: v1alpha1
 kind: LinkAliasConfig
 name: mgmt0
 selector:

--- a/talos/nodes/dvergar-06.yaml.j2
+++ b/talos/nodes/dvergar-06.yaml.j2
@@ -26,6 +26,12 @@ parent: mgmt0
 vlanID: 70
 ---
 apiVersion: v1alpha1
+kind: VLANConfig
+name: mgmt0.30
+parent: mgmt0
+vlanID: 30
+---
+apiVersion: v1alpha1
 kind: LinkAliasConfig
 name: mgmt0
 selector:

--- a/talos/nodes/elli.yaml.j2
+++ b/talos/nodes/elli.yaml.j2
@@ -43,6 +43,12 @@ parent: mgmt0
 vlanID: 70
 ---
 apiVersion: v1alpha1
+kind: VLANConfig
+name: mgmt0.30
+parent: mgmt0
+vlanID: 30
+---
+apiVersion: v1alpha1
 kind: LinkAliasConfig
 name: mgmt0
 selector:


### PR DESCRIPTION
## What

Adds a `VLANConfig mgmt0.30` block (VLAN 30 = true IoT, `10.1.30.x`) to all 8 node templates (`talos/nodes/*.yaml.j2`), mirroring the existing `mgmt0.70` VPN VLAN. No host IP is assigned — the interface exists purely as an **ipvlan-L2 parent** so Home Assistant can later attach to the IoT L2 (Google Cast / mDNS) via a multus `NetworkAttachmentDefinition`.

```yaml
kind: VLANConfig
name: mgmt0.30
parent: mgmt0
vlanID: 30
```

## Why

The Nest/Google Home speakers live on VLAN 30 (internet-allowed true IoT). HA runs in a pod and is doubly cut off from them: mDNS multicast doesn't cross VLANs, and Cilium SNAT means a speaker can't open the return media-pull connection back to an HA pod. Putting HA on the VLAN 30 L2 via ipvlan solves both. This PR is the cluster-side plumbing prerequisite. **No OPNsense changes** — Cast traffic stays on the VLAN 30 L2.

## Validation

- Every node template renders cleanly (`minijinja-cli`) and both `mgmt0.70` + `mgmt0.30` VLAN docs parse via `yq`.
- `clusterconfig/` is gitignored (holds secrets), so the diff is only the 8 templates.

## Required follow-up (not in this PR — live/physical)

1. **Brocade**: trunk VLAN 30 tagged to cluster ports + OPNsense uplink (`vlan 30 / tagged ethernet 1/1/13 to 1/1/19, 1/1/24, 1/2/1`). Ports already carry tagged VLAN 70, so no untagged-only "dance" needed.
2. **Apply** (bws-authed, canary first): `task talos:apply-node IP=192.168.100.20` → verify `talosctl get links mgmt0.30` → roll the rest. VLAN add is a no-reboot change.
3. **Next phase**: ipvlan-L2 NAD (`master: mgmt0.30`, static IP in `10.1.30.x`) + HA pod attachment for Cast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)