### PR TITLE
feat(home-assistant): attach IoT VLAN interface for Google Cast

### DIFF
--- a/kubernetes/apps/home-automation/home-assistant/README.md
+++ b/kubernetes/apps/home-automation/home-assistant/README.md
@@ -1,0 +1,39 @@
+# home-assistant
+
+Standard app-template HelmRelease (HA + code-server sidecar), dual-homed on
+the internal/external gateways. The non-obvious bit is the **IoT-VLAN secondary
+interface** for Google Cast.
+
+## IoT VLAN secondary interface (Google Cast)
+
+`networkattachment.yaml` + the `k8s.v1.cni.cncf.io/networks` pod annotation
+attach a second interface (`net1 = 10.1.30.5/24`) placing the HA pod directly on
+the IoT VLAN (VLAN 30, 10.1.30.0/24) where the Nest/Google Home speakers live.
+
+Why a dedicated L2 interface instead of routing:
+
+- **mDNS discovery is link-local multicast** — it doesn't cross VLANs, so a
+  pod-networked HA never sees the speakers.
+- **Cast pulls media back from HA** — Cilium SNATs pod egress to the node IP, so
+  a speaker can't open the return connection to a pod. Sharing the speakers' L2
+  fixes both discovery and the media-pull path.
+
+Implementation notes:
+
+- **ipvlan L2, not macvlan** — the cluster's Intel I219-V NICs silently drop
+  macvlan TX with synthesized MACs. ipvlan reuses the parent MAC.
+- **Parent `mgmt0.30`** is a tagged VLAN sub-interface defined in the Talos
+  config on all 8 nodes, so no `nodeSelector` is needed.
+- **No gateway in the NAD ipam** — only the connected /24 route lands on `net1`;
+  the pod's default route stays on `eth0` (cluster network). HA does not reach
+  the internet via VLAN 30.
+- **Per-pod IP via the annotation** (`capabilities.ips`) keeps the NAD reusable.
+- **`strategy: Recreate`** — the pod holds a fixed IP and an RWO config PVC, so a
+  rolling second pod would fail the multus IP claim and multi-attach the volume.
+
+### Runtime follow-up (not in manifests)
+
+After the pod has `net1`, the speakers need HA to advertise an IP they can reach
+for TTS/media. Point the Cast media base at `http://10.1.30.5:8123` (HA Cast
+integration / `internal_url` as appropriate) so served media is reachable on the
+VLAN 30 L2.

--- a/kubernetes/apps/home-automation/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/home-assistant/app/helmrelease.yaml
@@ -11,6 +11,8 @@ spec:
   values:
     controllers:
       home-assistant:
+        # Fixed IoT-VLAN IP + RWO PVC — no two pods at once. See ../README.md.
+        strategy: Recreate
         annotations:
           reloader.stakater.com/auto: "true"
         containers:
@@ -77,6 +79,10 @@ spec:
                 cpu: 10m
                 memory: 64Mi
     defaultPodOptions:
+      annotations:
+        # net1 on the IoT VLAN for Google Cast — see ../README.md.
+        k8s.v1.cni.cncf.io/networks: |
+          [{"name":"iot","namespace":"home-automation","ips":["10.1.30.5/24"]}]
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/kubernetes/apps/home-automation/home-assistant/app/kustomization.yaml
+++ b/kubernetes/apps/home-automation/home-assistant/app/kustomization.yaml
@@ -3,4 +3,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./externalsecret.yaml
+  - ./networkattachment.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/home-automation/home-assistant/app/networkattachment.yaml
+++ b/kubernetes/apps/home-automation/home-assistant/app/networkattachment.yaml
@@ -1,0 +1,23 @@
+---
+# Places the HA pod on the IoT VLAN (10.1.30.0/24) for Google Cast — see ../README.md.
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: iot
+spec:
+  config: |
+    {
+      "cniVersion": "0.3.1",
+      "name": "iot",
+      "plugins": [
+        {
+          "type": "ipvlan",
+          "master": "mgmt0.30",
+          "mode": "l2",
+          "capabilities": { "ips": true },
+          "ipam": {
+            "type": "static"
+          }
+        }
+      ]
+    }


### PR DESCRIPTION
## What

Puts the Home Assistant pod directly on the **IoT VLAN** (VLAN 30, `10.1.30.0/24`) via a multus ipvlan-L2 secondary interface, so **Google Cast** to the Nest/Home speakers works.

- `app/networkattachment.yaml` — `NetworkAttachmentDefinition` `iot` (ipvlan, `master: mgmt0.30`, mode l2, static IPAM, `capabilities.ips`).
- `app/helmrelease.yaml` — pod annotation `k8s.v1.cni.cncf.io/networks` → `net1 = 10.1.30.5/24`; `strategy: Recreate`.
- `README.md` — rationale.

Builds on the merged Talos change (#425) that added `mgmt0.30` to all 8 nodes (verified `up` cluster-wide).

## Why this shape

- **mDNS discovery is link-local multicast** — won't cross VLANs, so a pod-networked HA never sees the speakers.
- **Cast pulls media back from HA** — Cilium SNAT means a speaker can't open the return connection to a pod IP. Sharing the speakers' L2 fixes both.
- **ipvlan L2, not macvlan** — I219-V NICs drop macvlan TX with synthesized MACs.
- **`10.1.30.5`** is outside the dnsmasq DHCP pool (30.10–254) — no reservation needed; a CNI static-IPAM address isn't a DHCP client.
- **No gateway in ipam** — only the connected /24 route on `net1`; default route stays on `eth0`.
- **Recreate** — fixed IP + RWO PVC must never be held by two pods.

## After merge

1. HA pod restarts (Recreate) and comes up with `net1`. Verify: `kubectl exec -n home-automation deploy/home-assistant -c app -- ip -4 addr show net1` → `10.1.30.5`.
2. **Runtime HA config** (not in manifests): point the Cast media base / `internal_url` at `http://10.1.30.5:8123` so TTS/media is reachable on the VLAN 30 L2.
3. Confirm the speakers appear in HA's Google Cast integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)