### PR TITLE
fix(cilium): bypass bpf_host VLAN filter for VLANs 30 + 70

### DIFF
--- a/kubernetes/apps/kube-system/cilium/README.md
+++ b/kubernetes/apps/kube-system/cilium/README.md
@@ -1,0 +1,36 @@
+# cilium
+
+Primary CNI (kube-proxy replacement, native routing, Multus-compatible via
+`cni.exclusive: false`).
+
+## `bpf.vlanBypass` — required for Multus VLAN secondary networks
+
+Cilium's `bpf_host` program drops **all** 802.1Q-tagged frames on the native
+NIC by default, logged as `VLAN traffic disallowed by VLAN filter`
+(`bpf_host.c`). This silently breaks any Multus secondary network attached to a
+tagged VLAN sub-interface (`ipvlan`/`macvlan` on `mgmt0.<id>`): the pod gets its
+IP on `net1`, but every frame it sends is dropped at the host before reaching
+the wire — no ARP, no ping, nothing. It affects all CNI modes and is independent
+of NIC driver.
+
+`vlanBypass` allowlists VLAN IDs past that filter (`[0]` would bypass all).
+Current list:
+
+- **30** — IoT VLAN (`10.1.30.0/24`); Home Assistant ↔ Google Cast speakers.
+- **70** — VPN-egress VLAN; qbittorrent/slskd multus migration.
+
+Add a VLAN ID here whenever a new Multus tagged-VLAN attachment is introduced.
+
+### Diagnosing
+
+If a Multus VLAN pod can't reach its gateway, confirm before touching the switch
+or NICs — the host path usually works while the pod path doesn't:
+
+```sh
+# on the node's cilium agent:
+cilium-dbg monitor --type drop      # look for "VLAN traffic disallowed by VLAN filter"
+```
+
+Note: a host-netns test (adding an IP directly to `mgmt0.<id>` and pinging) will
+**succeed** even when this filter is blocking pods — only an actual pod on the
+secondary network exercises the dropped path.

--- a/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
@@ -14,6 +14,8 @@ spec:
       masquerade: true
       # Ref: https://github.com/siderolabs/talos/issues/10002
       hostLegacyRouting: true
+      # Multus VLAN secondary networks — see ../README.md. 30=IoT/Cast, 70=VPN.
+      vlanBypass: [30, 70]
     cni:
       # Required for pairing with Multus CNI
       exclusive: false


### PR DESCRIPTION
## Root cause

Multus secondary networks on tagged VLANs (the IoT/Cast attachment from #426, and the planned VPN-egress VLAN 70) were completely non-functional — pods got the right IP on `net1` but couldn't ARP/ping anything on the VLAN.

`cilium-dbg monitor --type drop` on the node pinned it:

```
xx drop (VLAN traffic disallowed by VLAN filter) bpf_host.c:1649  10.1.30.7 -> 10.1.30.1 icmp EchoRequest
xx drop (VLAN traffic disallowed by VLAN filter) bpf_host.c:1254  22:54:.. -> a0:36:.. ARP
```

Cilium's `bpf_host` program drops **all** 802.1Q-tagged frames on the native device unless the VLAN is allowlisted. The pod's tagged frames egress the physical NIC, Cilium sees them, and drops them — every CNI mode (ipvlan, macvlan, macvlan+promisc), both VLANs.

This was masked historically because only **host-level** arping (host netns on `mgmt0.70`) was ever tested — that path works fine; the *pod* path was never verified end-to-end.

### Ruled out (all healthy)
Switch trunking, OPNsense VLAN interfaces, NIC drivers (e1000e + r8169), ipvlan-vs-macvlan, and the Talos `mgmt0.30` config. Host-on-`mgmt0.30` reaches the gateway with 0% loss.

## Fix

`bpf.vlanBypass: [30, 70]` → `--vlan-bpf-bypass`, allowlisting IoT (30) and VPN-egress (70) past the filter.

## Rollout / risk

- Requires a **Cilium agent rolling restart** (DaemonSet) to recompile BPF — brief per-node dataplane blips, cluster-wide.
- Low risk: only changes which tagged VLANs bypass the host filter; no effect on pod/service networking. This is the documented way to run Multus VLAN secondary networks alongside Cilium.

## After merge
1. Cilium rolls out.
2. Re-test the HA `iot` attachment (ipvlan) → should now reach `10.1.30.x`. If mDNS multicast is flaky on ipvlan, switch the NAD to macvlan (better multicast) — separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)