### PR TITLE
fix(cnpg): drop memory limits on all Postgres clusters

### DIFF
--- a/kubernetes/apps/auth/authelia/db/cluster.yaml
+++ b/kubernetes/apps/auth/authelia/db/cluster.yaml
@@ -13,10 +13,9 @@ spec:
     size: 5Gi
     storageClass: ceph-block
   resources:
-    limits:
-      memory: 256Mi
     requests:
       cpu: 50m
+      memory: 256Mi
   bootstrap:
     recovery:
       source: authelia-pg-v1

--- a/kubernetes/apps/auth/lldap/db/cluster.yaml
+++ b/kubernetes/apps/auth/lldap/db/cluster.yaml
@@ -13,10 +13,9 @@ spec:
     size: 5Gi
     storageClass: ceph-block
   resources:
-    limits:
-      memory: 256Mi
     requests:
       cpu: 50m
+      memory: 256Mi
   bootstrap:
     recovery:
       source: lldap-pg-v1

--- a/kubernetes/apps/default/reactive-resume/db/cluster.yaml
+++ b/kubernetes/apps/default/reactive-resume/db/cluster.yaml
@@ -13,10 +13,9 @@ spec:
     size: 5Gi
     storageClass: ceph-block
   resources:
-    limits:
-      memory: 256Mi
     requests:
       cpu: 50m
+      memory: 256Mi
   bootstrap:
     recovery:
       source: reactive-resume-pg-v1

--- a/kubernetes/apps/default/vikunja/db/cluster.yaml
+++ b/kubernetes/apps/default/vikunja/db/cluster.yaml
@@ -13,10 +13,9 @@ spec:
     size: 5Gi
     storageClass: ceph-block
   resources:
-    limits:
-      memory: 512Mi
     requests:
       cpu: 50m
+      memory: 512Mi
   bootstrap:
     recovery:
       source: vikunja-pg-v1

--- a/kubernetes/apps/hermod/hermod-db/db/api-cluster.yaml
+++ b/kubernetes/apps/hermod/hermod-db/db/api-cluster.yaml
@@ -13,10 +13,9 @@ spec:
     size: 5Gi
     storageClass: ceph-block
   resources:
-    limits:
-      memory: 256Mi
     requests:
       cpu: 50m
+      memory: 256Mi
   bootstrap:
     initdb:
       database: app

--- a/kubernetes/apps/hermod/hermod-db/db/auth-cluster.yaml
+++ b/kubernetes/apps/hermod/hermod-db/db/auth-cluster.yaml
@@ -13,10 +13,9 @@ spec:
     size: 5Gi
     storageClass: ceph-block
   resources:
-    limits:
-      memory: 256Mi
     requests:
       cpu: 50m
+      memory: 256Mi
   bootstrap:
     initdb:
       database: app

--- a/kubernetes/apps/hermod/hermod-db/db/bot-cluster.yaml
+++ b/kubernetes/apps/hermod/hermod-db/db/bot-cluster.yaml
@@ -13,10 +13,9 @@ spec:
     size: 5Gi
     storageClass: ceph-block
   resources:
-    limits:
-      memory: 256Mi
     requests:
       cpu: 50m
+      memory: 256Mi
   bootstrap:
     initdb:
       database: app

--- a/kubernetes/components/cnpg-cluster/cluster.yaml
+++ b/kubernetes/components/cnpg-cluster/cluster.yaml
@@ -20,10 +20,9 @@ spec:
     size: "${CNPG_CAPACITY:=5Gi}"
     storageClass: "${CNPG_STORAGECLASS:=ceph-block}"
   resources:
-    limits:
-      memory: "${CNPG_MEMORY_LIMIT:=256Mi}"
     requests:
       cpu: "${CNPG_CPU_REQUEST:=50m}"
+      memory: "${CNPG_MEMORY_REQUEST:=256Mi}"
   # For first deploy (no backup exists yet), temporarily change to:
   #   bootstrap:
   #     initdb:


### PR DESCRIPTION
## Why

Every CNPG Postgres cluster except `mealie-pg` shipped a memory **limit** (`256Mi`, `512Mi` for vikunja), from both the `components/cnpg-cluster` default and hardcoded per-app `db/cluster.yaml` overrides. That contradicts the requests-only / no-memory-limits practice — and because setting only a limit makes k8s mirror it as the request, these pods are hard-capped. Any WAL-recovery or replica-rejoin spike OOMKills Postgres **even though the node is ~80% free**.

This surfaced when the Cilium `vlanBypass` rollout (#427) restarted networking cluster-wide: a blip tripped `authelia-pg`'s CNPG liveness probe → Postgres restart → recovery exceeded 256Mi → OOM loop. CNPG failed over to the replica so Authelia stayed up, but pg-1 couldn't rejoin.

## Change

`limits.memory` → `requests.memory` (same values preserved) across:

- `components/cnpg-cluster/cluster.yaml` (var renamed `CNPG_MEMORY_LIMIT` → `CNPG_MEMORY_REQUEST`; only self-referenced)
- `auth/authelia`, `auth/lldap`, `hermod/{api,auth,bot}`, `default/vikunja` (512Mi), `default/reactive-resume`

Request still reserves capacity for scheduling; dropping the limit lets Postgres burst during recovery instead of OOMing.

## Rollout

CNPG does a rolling switchover per cluster on apply — brief, and replicas cover it. Watch `authelia-pg` rejoin afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)