### PR TITLE
fix(external-secrets): read Bitwarden CA from bitwarden-ca-certs

### DIFF
--- a/kubernetes/apps/external-secrets/external-secrets/app/clustersecretstore.yaml
+++ b/kubernetes/apps/external-secrets/external-secrets/app/clustersecretstore.yaml
@@ -15,7 +15,7 @@ spec:
       bitwardenServerSDKURL: https://bitwarden-sdk-server.external-secrets.svc.cluster.local:9998
       caProvider:
         type: Secret
-        name: bitwarden-tls-certs
+        name: bitwarden-ca-certs
         namespace: external-secrets
         key: ca.crt
       organizationID: 86a45a90-4e27-431a-8a6a-b2ed005257f3


### PR DESCRIPTION
## Problem

All 77 ExternalSecrets were in `SecretSyncedError` from 2026-06-13 to 2026-07-02 (19 days), cascading to 14 failing Flux kustomizations.

Root cause: the `ClusterSecretStore/bitwarden-secretsmanager` caProvider reads `ca.crt` from the **leaf** secret `bitwarden-tls-certs`. That key is only stamped at leaf issuance, so when the bootstrap CA rotated on 2026-06-13, the leaf secret kept the expired CA generation and ESO could no longer verify the bitwarden-sdk-server.

## Fix

Point the caProvider at `bitwarden-ca-certs` — the bootstrap Certificate's own secret, which cert-manager keeps current on every CA rotation. This eliminates the rotation race permanently.

## Immediate remediation (already done imperatively)

- Deleted `bitwarden-tls-certs` secret → cert-manager re-issued with current CA
- Restarted bitwarden-sdk-server
- All 77 ExternalSecrets back to `SecretSynced`, all 95 kustomizations + all HelmReleases Ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015kPuDY2vaQuXAGpCV3BycM