### PR TITLE
feat(observability): alert on ExternalSecret sync failures and Flux resources not Ready

### DIFF
--- a/kubernetes/apps/external-secrets/external-secrets/app/kustomization.yaml
+++ b/kubernetes/apps/external-secrets/external-secrets/app/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - ./certificate.yaml
   - ./clustersecretstore.yaml
   - ./helmrelease.yaml
+  - ./prometheusrule.yaml
 configMapGenerator:
   - name: external-secrets-values
     files:

--- a/kubernetes/apps/external-secrets/external-secrets/app/prometheusrule.yaml
+++ b/kubernetes/apps/external-secrets/external-secrets/app/prometheusrule.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: external-secrets
+spec:
+  groups:
+    - name: external-secrets.rules
+      rules:
+        - alert: ExternalSecretsComponentAbsent
+          expr: |
+            absent(up{job="external-secrets-metrics"})
+          annotations:
+            summary: >-
+              external-secrets has disappeared from Prometheus target discovery
+          for: 15m
+          labels:
+            severity: critical
+
+        - alert: ExternalSecretNotSynced
+          expr: |
+            externalsecret_status_condition{condition="Ready", status="False"} == 1
+          annotations:
+            summary: >-
+              ExternalSecret {{ $labels.exported_namespace }}/{{ $labels.name }} has not synced for over an hour
+          for: 1h
+          labels:
+            severity: critical

--- a/kubernetes/apps/flux-system/flux-instance/app/kustomization.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/app/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - ./httproute.yaml
   - ./receiver.yaml
   - ./ocirepository.yaml
+  - ./prometheusrule.yaml

--- a/kubernetes/apps/flux-system/flux-instance/app/prometheusrule.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/app/prometheusrule.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: flux-instance
+spec:
+  groups:
+    - name: flux-instance.rules
+      rules:
+        - alert: FluxResourceNotReady
+          expr: |
+            flux_resource_info{kind=~"Kustomization|HelmRelease", ready!="True", suspended="False"}
+          annotations:
+            summary: >-
+              Flux {{ $labels.kind }} {{ $labels.exported_namespace }}/{{ $labels.name }} has not been Ready for over an hour
+          for: 1h
+          labels:
+            severity: critical


### PR DESCRIPTION
## Why

The Bitwarden CA expiry (fixed in #452) broke all 77 ExternalSecrets for **19 days without firing a single alert** — Ceph crashes page, but ESO/Flux failures didn't.

## What

Two PrometheusRules, following the existing volsync/gatus pattern:

**`external-secrets`** (kubernetes/apps/external-secrets/external-secrets/app):
- `ExternalSecretsComponentAbsent` — ESO vanished from target discovery (15m, critical)
- `ExternalSecretNotSynced` — any ExternalSecret not Ready for 1h (critical)

**`flux-instance`** (kubernetes/apps/flux-system/flux-instance/app):
- `FluxResourceNotReady` — any non-suspended Kustomization/HelmRelease not Ready for 1h (critical), via `flux_resource_info` from flux-operator

Metrics verified live in Prometheus (`externalsecret_status_condition`, `flux_resource_info` with `ready`/`suspended=True|False` labels). Both kustomize builds pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015kPuDY2vaQuXAGpCV3BycM