### PR TITLE
feat(mariadb): enable MARIADB_AUTO_UPGRADE for the 11.8 to 12.3 jump

### DIFF
--- a/kubernetes/apps/media/mariadb/app/helmrelease.yaml
+++ b/kubernetes/apps/media/mariadb/app/helmrelease.yaml
@@ -21,6 +21,7 @@ spec:
               tag: 11.8.8
             env:
               TZ: America/Chicago
+              MARIADB_AUTO_UPGRADE: "1"
               MARIADB_DATABASE: booklore
               MARIADB_USER: booklore
               MARIADB_ROOT_PASSWORD:


### PR DESCRIPTION
Prep for #123 (MariaDB 11.8.8 → 12.3.2, now an LTS→LTS upgrade). The official image skips system-table migration on major version jumps unless `MARIADB_AUTO_UPGRADE=1`.

Pre-upgrade safety net already taken: full `mariadb-dump` (verified, stored off-cluster) + fresh VolSync snapshot of the PVC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015kPuDY2vaQuXAGpCV3BycM