### PR TITLE
fix(cilium): exclude node IPs from LB-IPAM pool, pin mc-router IP

### DIFF
--- a/kubernetes/apps/kube-system/cilium/app/networks.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/networks.yaml
@@ -5,8 +5,14 @@ metadata:
   name: pool
 spec:
   allowFirstLastIPs: "No"
+  # Exclude node IPs (.20-.30) and the control-plane VIP (.5): a full-/24 pool
+  # let LB-IPAM assign a node's own IP to a Service, and the L2 announcer then
+  # ARP-hijacked that node (2026-07-16 incident: mc-router got dvergar-00's .20).
   blocks:
-    - cidr: "192.168.100.0/24"
+    - start: "192.168.100.10"
+      stop: "192.168.100.19"
+    - start: "192.168.100.32"
+      stop: "192.168.100.63"
 ---
 apiVersion: cilium.io/v2alpha1
 kind: CiliumL2AnnouncementPolicy

--- a/kubernetes/apps/minecraft/mc-router/app/helmrelease.yaml
+++ b/kubernetes/apps/minecraft/mc-router/app/helmrelease.yaml
@@ -41,6 +41,7 @@ spec:
         nodePort: 30565
         annotations:
           external-dns.alpha.kubernetes.io/hostname: mc.${SECRET_DOMAIN}, *.mc.${SECRET_DOMAIN}
+          lbipam.cilium.io/ips: 192.168.100.36
     minecraftRouter:
       debug:
         enabled: true


### PR DESCRIPTION
## Incident (2026-07-16, during cilium 1.18.6→1.19.5 rollout)

`minecraft/mc-router` (unpinned LoadBalancer) was assigned **192.168.100.20 — node dvergar-00's IP** by LB-IPAM, whose pool was the entire `192.168.100.0/24`. The CiliumL2AnnouncementPolicy lease holder for mc-router (dvergar-01) began answering ARP for .20, poisoning ARP caches on dvergar-02/05/06/elli. Result: dvergar-00's etcd member partitioned from the leader (quorum held at 2/3), kubelet lost the apiserver, node NotReady, pods on it crashlooping.

This conflict also plausibly explains weeks of intermittent dvergar-00 anomalies (etcd gRPC alert pinned to dvergar-00, mon liveness blip on Jul 2, flaky Talos API) — each agent restart re-GARPs and re-poisons caches.

## Fix
- Pool restricted to `.10–.19` + `.32–.63`: excludes node IPs (.20–.30) and the control-plane VIP (.5). All currently assigned IPs (envoy .10/.12, abiotic .18, netboot .19, plex .35) remain valid.
- mc-router pinned to `192.168.100.36` via `lbipam.cilium.io/ips` (every other LB service was already pinned; this was the only floater).

## Rollout notes
Merging this moves mc-router's IP .20 → .36 (external-dns updates `mc.*` automatically). After Flux applies it, stale ARP entries for .20 on the poisoned nodes need to age out or be flushed, then dvergar-00's etcd/kubelet recover on their own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015kPuDY2vaQuXAGpCV3BycM