### PR TITLE
feat(talos): lower kubelet image GC thresholds to 60/50

### DIFF
--- a/talos/machineconfig.yaml.j2
+++ b/talos/machineconfig.yaml.j2
@@ -47,6 +47,10 @@ machine:
     disableManifestsDirectory: true
     extraConfig:
       serializeImagePulls: false
+      # GC unused images at 60% disk instead of the 85% default — ceph mons
+      # warn at 70% (MON_DISK_LOW), so default GC never runs before the alert
+      imageGCHighThresholdPercent: 60
+      imageGCLowThresholdPercent: 50
     image: ghcr.io/siderolabs/kubelet:{{ ENV.KUBERNETES_VERSION }}
     nodeIP:
       validSubnets:


### PR DESCRIPTION
Fleet-wide durable fix for the image-hoard problem found tonight: dvergar-05 hit ceph's `MON_DISK_LOW` (70% disk) with **123GB / 1,057 images** of superseded Renovate versions, because kubelet's default image GC threshold is 85% — it never runs before the mon warning fires.

`imageGCHighThresholdPercent: 60` / `imageGCLowThresholdPercent: 50` makes kubelet clean unused images down to 50% whenever disk crosses 60%, keeping every node safely below the mon threshold forever.

**Apply procedure (needs bws env):** merge, then `task talos:apply-node IP=<ip>` per node — kubelet restarts in place, no reboot. No urgency: dvergar-05 was manually pruned tonight (871 stale refs removed), so this is prevention, not remediation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015kPuDY2vaQuXAGpCV3BycM