### PR TITLE
feat(media): production NAD for VPN VLAN 70 (ipvlan + sbr)

### DIFF
--- a/kubernetes/apps/media/kustomization.yaml
+++ b/kubernetes/apps/media/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
   - ./plex/ks.yaml
   - ./prowlarr/ks.yaml
   - ./qbittorrent/ks.yaml
+  - ./vpn-network/ks.yaml
   - ./radarr/ks.yaml
   - ./radarr4k/ks.yaml
   - ./recyclarr/ks.yaml

--- a/kubernetes/apps/media/vpn-network/README.md
+++ b/kubernetes/apps/media/vpn-network/README.md
@@ -1,0 +1,36 @@
+# vpn-network
+
+`vpn-vlan70` NetworkAttachmentDefinition: a second NIC (`net1`) on VLAN 70,
+where OPNsense policy-routes everything through the AirVPN WireGuard tunnel
+(`wg0`). Replaces the gluetun-sidecar pattern for qbittorrent/slskd.
+
+## How it works
+
+- **ipvlan L2** on `mgmt0.70` — the Talos `VLANConfig` sub-interface that
+  exists (unnumbered, by design) on every node; nodes themselves have no IP
+  on VLAN 70 and never should (VLAN 70 egress goes through the VPN).
+- **sbr** meta-plugin chained after ipvlan — converts `net1`'s routes into
+  per-source-IP rules, so replies to inbound (port-forwarded) connections
+  leave via `net1` instead of being dropped by cilium on `eth0`
+  ("Invalid source ip").
+- **static IPAM** — each pod pins its IP via the multus annotation:
+
+  ```yaml
+  k8s.v1.cni.cncf.io/networks: |
+    [{ "name": "vpn-vlan70", "namespace": "media", "ips": ["192.168.70.32/24"] }]
+  ```
+
+## IP plan (192.168.70.0/24)
+
+| IP | Use |
+|---|---|
+| .1 | OPNsense gateway |
+| .20–.30 | RESERVED — never allocate (mirrors node last-octets on VLAN 100; see the 2026-07-16 LB-IPAM/node-IP collision incident) |
+| .32 | qbittorrent |
+| .33 | slskd |
+| .34–.62 | future VPN workloads |
+
+Kill-switch and inbound port-forwarding live in OPNsense (NO_WAN_EGRESS tag
+mechanism; Destination NAT with `reply-to` on the wg interface). Cilium must
+keep `bpf.vlanBypass: [30, 70]` for tagged VLAN traffic to pass the host
+datapath.

--- a/kubernetes/apps/media/vpn-network/app/kustomization.yaml
+++ b/kubernetes/apps/media/vpn-network/app/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./networkattachmentdefinition.yaml

--- a/kubernetes/apps/media/vpn-network/app/networkattachmentdefinition.yaml
+++ b/kubernetes/apps/media/vpn-network/app/networkattachmentdefinition.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: vpn-vlan70
+spec:
+  config: |-
+    {
+      "cniVersion": "1.0.0",
+      "name": "vpn-vlan70",
+      "plugins": [
+        {
+          "type": "ipvlan",
+          "master": "mgmt0.70",
+          "mode": "l2",
+          "capabilities": { "ips": true },
+          "ipam": {
+            "type": "static",
+            "routes": [
+              { "dst": "0.0.0.0/0", "gw": "192.168.70.1" }
+            ]
+          }
+        },
+        { "type": "sbr" }
+      ]
+    }

--- a/kubernetes/apps/media/vpn-network/ks.yaml
+++ b/kubernetes/apps/media/vpn-network/ks.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app vpn-network
+  namespace: &namespace media
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: multus
+      namespace: kube-system
+  interval: 1h
+  path: ./kubernetes/apps/media/vpn-network/app
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false


### PR DESCRIPTION
Step 2 of the gluetun retirement sequence (cilium 1.19 ✅ was step 1).

Adds `media/vpn-vlan70` NetworkAttachmentDefinition — ipvlan L2 on `mgmt0.70` chained with the **sbr** meta-plugin, static IPAM via pod annotation. sbr converts net1's routes into per-source rules so port-forwarded inbound replies exit net1 instead of dying in cilium on eth0 (the "Invalid source ip" drop we debugged in testing).

**IP plan** (README): `.20–.30` reserved (node-aligned last octets — lesson of the 07-16 LB-IPAM collision), `.32` qbittorrent, `.33` slskd, `.34–.62` future.

**Pre-verified:**
- VLAN-70 egress via AirVPN wg0 from **elli** and **dvergar-05** (qbit's current node)
- `bpf.vlanBypass: [30, 70]` intact on cilium 1.19.5
- Inbound DNAT + reply-to + kill-switch patterns proven on the test rig (2026-07-09/10)

**Not in this PR:** the qbittorrent/slskd annotation + gluetun-sidecar removal (cutover step, needs the OPNsense DNAT re-point to .32/.33 alongside), and a VLAN-70 reachability sweep of the remaining nodes if we want unrestricted scheduling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015kPuDY2vaQuXAGpCV3BycM