### PR TITLE
fix(slskd): correct routing init script (onlink, node subnet, idempotent)

### DIFF
--- a/kubernetes/apps/media/slskd/app/helmrelease.yaml
+++ b/kubernetes/apps/media/slskd/app/helmrelease.yaml
@@ -35,8 +35,9 @@ spec:
               - |
                 set -e
                 GW=$(ip route show default dev eth0 | awk '{print $3}')
-                ip route add 10.42.0.0/15 via "$GW" dev eth0
-                ip route replace default via 192.168.70.1 dev net1
+                ip route replace 10.42.0.0/15 via "$GW" dev eth0
+                ip route replace 192.168.100.0/24 via "$GW" dev eth0
+                ip route replace default via 192.168.70.1 dev net1 onlink
                 ip route show
             securityContext:
               runAsNonRoot: false


### PR DESCRIPTION
Follow-up to #499 — the routing init script needed three corrections (already live via imperative patch, verified working; this makes git match):

1. `onlink` on the net1 default route — sbr moves the connected VLAN route into table 100, so the main table can't resolve the gateway without it (`Init:Error`)
2. `192.168.100.0/24` via eth0 — kubelet probes come from the node; their replies were riding the VPN default and timing out (liveness kill loop). Gluetun's `FIREWALL_OUTBOUND_SUBNETS` had documented exactly this subnet list.
3. `ip route replace` for idempotent init retries.

**Verified live:** slskd 1/1, Soulseek connected+logged in, unbound egress = AirVPN wg0 exit (134.19.179.243), sbr rule present, clean pod rebuild from scratch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015kPuDY2vaQuXAGpCV3BycM