### PR TITLE
feat(qbittorrent): cut over to VPN VLAN 70, drop gluetun sidecar

### DIFF
--- a/kubernetes/apps/media/qbittorrent/app/helmrelease.yaml
+++ b/kubernetes/apps/media/qbittorrent/app/helmrelease.yaml
@@ -14,9 +14,42 @@ spec:
       qbittorrent:
         annotations:
           reloader.stakater.com/auto: "true"
+        pod:
+          annotations:
+            k8s.v1.cni.cncf.io/networks: |
+              [{
+                "name": "vpn-vlan70",
+                "namespace": "media",
+                "ips": ["192.168.70.32/24"]
+              }]
+        initContainers:
+          # Route all non-cluster egress (qbittorrent AND mousehole) via the
+          # VPN VLAN — see ../vpn-network/README.md
+          routing:
+            image:
+              repository: ghcr.io/nicolaka/netshoot
+              tag: v0.16@sha256:b09d9b21381f47a79b3cbcb30da25266dc17186ea00ae65e99fdc51396f48e70
+            command:
+              - /bin/bash
+              - -c
+              - |
+                set -e
+                GW=$(ip route show default dev eth0 | awk '{print $3}')
+                ip route replace 10.42.0.0/15 via "$GW" dev eth0
+                ip route replace 192.168.100.0/24 via "$GW" dev eth0
+                ip route replace default via 192.168.70.1 dev net1 onlink
+                ip route show
+            securityContext:
+              runAsNonRoot: false
+              runAsUser: 0
+              capabilities:
+                add: ["NET_ADMIN"]
+            resources:
+              requests:
+                cpu: 5m
+                memory: 16Mi
         containers:
           app:
-            dependsOn: gluetun
             image:
               repository: ghcr.io/home-operations/qbittorrent-libtorrentv1
               tag: 5.2.2
@@ -43,56 +76,7 @@ spec:
               requests:
                 cpu: 50m
                 memory: 1Gi
-          gluetun:
-            image:
-              repository: ghcr.io/qdm12/gluetun
-              tag: v3.39.1
-            env:
-              TZ: America/Chicago
-              VPN_TYPE: wireguard
-              DOT: "off"
-              DNS_KEEP_NAMESERVER: "on"
-              HEALTH_SERVER_ADDRESS: "0.0.0.0:9999"
-              HEALTH_VPN_DURATION_INITIAL: "15s"
-              FIREWALL_INPUT_PORTS: "8080,9999,5010"
-              FIREWALL_VPN_INPUT_PORTS: "35338"
-              FIREWALL_OUTBOUND_SUBNETS: "10.42.0.0/15,192.168.100.0/24"
-            envFrom:
-              - secretRef:
-                  name: qbittorrent-secret
-            probes:
-              startup:
-                enabled: true
-                custom: true
-                spec:
-                  httpGet:
-                    path: /
-                    port: 9999
-                  initialDelaySeconds: 10
-                  periodSeconds: 10
-                  timeoutSeconds: 10
-                  failureThreshold: 30
-              liveness:
-                enabled: true
-                custom: true
-                spec:
-                  httpGet:
-                    path: /
-                    port: 9999
-                  periodSeconds: 30
-                  timeoutSeconds: 10
-                  failureThreshold: 5
-            securityContext:
-              runAsNonRoot: false
-              runAsUser: 0
-              capabilities:
-                add: ["NET_ADMIN", "MKNOD", "NET_RAW"]
-            resources:
-              requests:
-                cpu: 10m
-                memory: 256Mi
           mousehole:
-            dependsOn: gluetun
             image:
               repository: tmmrtn/mousehole
               tag: 0.5.0
@@ -197,12 +181,6 @@ spec:
           qbittorrent:
             app:
               - path: /tmp
-      gluetun-data:
-        type: emptyDir
-        advancedMounts:
-          qbittorrent:
-            gluetun:
-              - path: /tmp/gluetun
       mousehole-data:
         existingClaim: mousehole
         advancedMounts:


### PR DESCRIPTION
Second and final gluetun workload cutover (slskd was #499/#500).

- multus annotation, static IP **192.168.70.32**
- gluetun sidecar + emptyDir removed; `dependsOn` dropped from app + mousehole
- routing init container (identical to slskd's proven script): cluster subnets on eth0, default via VLAN 70 — covers libtorrent, qbit app HTTP (RSS/URL fetches), **and mousehole's MAM session announcements**
- `QBT_TORRENTING_PORT: 35338` unchanged; OPNsense DNAT 35338→.32 already staged by user; AirVPN port→device re-link after rollout

After this lands and verifies, gluetun is fully retired → #269/#270/#115.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015kPuDY2vaQuXAGpCV3BycM