### PR TITLE
feat(matter-server): add python-matter-server for Matter-over-Thread

### DIFF
--- a/kubernetes/apps/home-automation/kustomization.yaml
+++ b/kubernetes/apps/home-automation/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - ./mosquitto/ks.yaml
   - ./frigate/ks.yaml
   - ./home-assistant/ks.yaml
+  - ./matter-server/ks.yaml
   - ./zigbee2mqtt/ks.yaml
   - ./esphome/ks.yaml
   - ./ollama/ks.yaml

--- a/kubernetes/apps/home-automation/matter-server/README.md
+++ b/kubernetes/apps/home-automation/matter-server/README.md
@@ -1,0 +1,69 @@
+# matter-server
+
+[python-matter-server](https://github.com/home-assistant-libs/python-matter-server) —
+the Matter controller for Home Assistant. HA runs as Core in a container (no
+Supervisor), so the "official Matter Server add-on" path doesn't exist here;
+this deployment is its replacement. HA connects via the Matter integration
+with the add-on checkbox **unchecked** and the URL
+`ws://matter-server.home-automation.svc.cluster.local:5580/ws`.
+
+The Thread radio side is the SMLIGHT SM Hub Nano (`smhub.internal`) running
+OpenThread Border Router on the IoT VLAN; HA talks to it separately via the
+OTBR integration (`tcp://smhub.internal:8081`).
+
+## Why the multus `iot` attachment (net1 = 10.1.30.6)
+
+Matter-over-Thread requires the controller to share an L2 domain with the
+border router, for two link-local mechanisms that never cross VLANs:
+
+1. **mDNS** — the OTBR advertises itself (`_meshcop._udp`) and proxies Thread
+   devices' Matter service records onto the infrastructure link.
+2. **IPv6 Router Advertisements** — the OTBR announces the route into the
+   Thread mesh (its OMR prefix) as an RA Route Information Option. Without
+   that route, commissioning hands off to Thread and then times out.
+
+The pod therefore attaches to the existing `iot`
+NetworkAttachmentDefinition (ipvlan L2 on `mgmt0.30`, owned by the
+home-assistant app — hence the `dependsOn` in `ks.yaml`) with the static IP
+`10.1.30.6/24`, right next to HA's `10.1.30.5`. Both sit outside the dnsmasq
+DHCP pool (.10–.254) because CNI static IPAM is not a DHCP client.
+`--primary-interface net1` points the SDK at the IoT-VLAN interface.
+
+## The sysctl initContainer
+
+Linux **ignores RA Route Information Options by default**
+(`accept_ra_rt_info_max_plen=0`), so the privileged initContainer sets, on
+`net1` only:
+
+- `net.ipv6.conf.net1.accept_ra=2` — accept RAs regardless of forwarding state
+- `net.ipv6.conf.net1.accept_ra_rt_info_max_plen=64` — install RIO routes up
+  to /64 (the Thread OMR prefix length)
+
+These are netns-scoped (they don't touch the node), but they're not on
+kubelet's safe-sysctl list, so a privileged init is simpler than an
+allowed-unsafe-sysctls kubelet change on all nodes. Verify after rollout:
+
+```sh
+kubectl -n home-automation exec deploy/matter-server -- ip -6 route show dev net1
+# expect: fd..::/64 via fe80::... proto ra
+```
+
+## Storage
+
+`/data` holds the **Matter fabric credentials** — losing it means
+re-commissioning every Matter device. It's a volsync-backed PVC (1Gi,
+ceph-block) so it rides the normal kopia backup schedule. PAA root
+certificates are fetched from the DCL into `/data/credentials` at startup.
+
+## No route / no auth
+
+The websocket API on 5580 is unauthenticated by design (the add-on relies on
+the Supervisor network for isolation). ClusterIP only — never expose it via
+HTTPRoute.
+
+## Image tag note
+
+Upstream releases 8.1.1/8.1.2 exist as git tags only — **no container images
+were published** for them (verified against ghcr directly); 8.1.0 is the
+newest image, and `stable` points at it. Renovate will pick up the next
+published image.

--- a/kubernetes/apps/home-automation/matter-server/README.md
+++ b/kubernetes/apps/home-automation/matter-server/README.md
@@ -1,10 +1,13 @@
 # matter-server
 
-[python-matter-server](https://github.com/home-assistant-libs/python-matter-server) —
-the Matter controller for Home Assistant. HA runs as Core in a container (no
-Supervisor), so the "official Matter Server add-on" path doesn't exist here;
-this deployment is its replacement. HA connects via the Matter integration
-with the add-on checkbox **unchecked** and the URL
+[matterjs-server](https://github.com/matter-js/matterjs-server) — the Open
+Home Foundation Matter controller for Home Assistant, successor to
+[python-matter-server](https://github.com/home-assistant-libs/python-matter-server)
+(8.1.2 was that project's final release; this is the matter.js rewrite with a
+compatible WebSocket API). HA runs as Core in a container (no Supervisor), so
+the "official Matter Server add-on" path doesn't exist here; this deployment
+is its replacement. HA connects via the Matter integration with the add-on
+checkbox **unchecked** and the URL
 `ws://matter-server.home-automation.svc.cluster.local:5580/ws`.
 
 The Thread radio side is the SMLIGHT SM Hub Nano (`smhub.internal`) running
@@ -27,7 +30,8 @@ NetworkAttachmentDefinition (ipvlan L2 on `mgmt0.30`, owned by the
 home-assistant app — hence the `dependsOn` in `ks.yaml`) with the static IP
 `10.1.30.6/24`, right next to HA's `10.1.30.5`. Both sit outside the dnsmasq
 DHCP pool (.10–.254) because CNI static IPAM is not a DHCP client.
-`--primary-interface net1` points the SDK at the IoT-VLAN interface.
+`PRIMARY_INTERFACE=net1` points the SDK at the IoT-VLAN interface (the image
+is configured entirely through env vars; `STORAGE_PATH=/data` is its default).
 
 ## The sysctl initContainer
 
@@ -52,18 +56,19 @@ kubectl -n home-automation exec deploy/matter-server -- ip -6 route show dev net
 
 `/data` holds the **Matter fabric credentials** — losing it means
 re-commissioning every Matter device. It's a volsync-backed PVC (1Gi,
-ceph-block) so it rides the normal kopia backup schedule. PAA root
-certificates are fetched from the DCL into `/data/credentials` at startup.
+ceph-block) so it rides the normal kopia backup schedule. The image bakes in
+`USER 1000:1000`, matching the pod securityContext/fsGroup.
 
 ## No route / no auth
 
-The websocket API on 5580 is unauthenticated by design (the add-on relies on
-the Supervisor network for isolation). ClusterIP only — never expose it via
-HTTPRoute.
+The websocket API and dashboard on 5580 are unauthenticated by design (the
+add-on relies on the Supervisor network for isolation). ClusterIP only —
+never expose it via HTTPRoute. Reach the dashboard with a port-forward when
+needed.
 
-## Image tag note
+## Version note
 
-Upstream releases 8.1.1/8.1.2 exist as git tags only — **no container images
-were published** for them (verified against ghcr directly); 8.1.0 is the
-newest image, and `stable` points at it. Renovate will pick up the next
-published image.
+matterjs-server is beta (not yet CSA re-certified) but is the only maintained
+line — upstream declared python-matter-server end-of-life and its 8.1.1/8.1.2
+releases never even shipped container images. Drop-in WS-API replacement,
+supports Matter 1.4.2.

--- a/kubernetes/apps/home-automation/matter-server/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/matter-server/app/helmrelease.yaml
@@ -33,23 +33,18 @@ spec:
         containers:
           app:
             image:
-              repository: ghcr.io/home-assistant-libs/python-matter-server
-              tag: 8.1.0@sha256:170aa093ce91c76cde4cc390918307590f0f5558fcec93f913af3cb019e6562a
-            args:
-              - --storage-path
-              - /data
-              - --paa-root-cert-dir
-              - /data/credentials
-              - --primary-interface
-              - net1
+              repository: ghcr.io/matter-js/matterjs-server
+              tag: 1.2.7@sha256:3f2b19c26fa21f9a855fd1e31cc8e1b174e8fcece881ab4ac7f56b5d828446a6
             env:
               TZ: America/Chicago
+              PRIMARY_INTERFACE: net1
             probes:
               liveness: &probes
                 enabled: true
                 custom: true
                 spec:
-                  tcpSocket:
+                  httpGet:
+                    path: /health
                     port: &port 5580
                   initialDelaySeconds: 0
                   periodSeconds: 10

--- a/kubernetes/apps/home-automation/matter-server/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/matter-server/app/helmrelease.yaml
@@ -18,7 +18,7 @@ spec:
           sysctl:
             image:
               repository: ghcr.io/home-operations/busybox
-              tag: 1.38.0
+              tag: 1.38.0@sha256:7e2c04dd50ede647bf4a7a4c8dbd629dd4971cd139b9b88fb22bfc3c7a6c13df
             command:
               - sh
               - -c
@@ -34,7 +34,7 @@ spec:
           app:
             image:
               repository: ghcr.io/home-assistant-libs/python-matter-server
-              tag: 8.1.0
+              tag: 8.1.0@sha256:170aa093ce91c76cde4cc390918307590f0f5558fcec93f913af3cb019e6562a
             args:
               - --storage-path
               - /data

--- a/kubernetes/apps/home-automation/matter-server/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/matter-server/app/helmrelease.yaml
@@ -1,0 +1,93 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: matter-server
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 1h
+  values:
+    controllers:
+      matter-server:
+        # Fixed IoT-VLAN IP + RWO PVC — no two pods at once. See ../README.md.
+        strategy: Recreate
+        initContainers:
+          # Accept the OTBR's route into the Thread mesh on net1 — see ../README.md.
+          sysctl:
+            image:
+              repository: ghcr.io/home-operations/busybox
+              tag: 1.38.0
+            command:
+              - sh
+              - -c
+              - >-
+                sysctl -w
+                net.ipv6.conf.net1.accept_ra=2
+                net.ipv6.conf.net1.accept_ra_rt_info_max_plen=64
+            securityContext:
+              privileged: true
+              runAsNonRoot: false
+              runAsUser: 0
+        containers:
+          app:
+            image:
+              repository: ghcr.io/home-assistant-libs/python-matter-server
+              tag: 8.1.0
+            args:
+              - --storage-path
+              - /data
+              - --paa-root-cert-dir
+              - /data/credentials
+              - --primary-interface
+              - net1
+            env:
+              TZ: America/Chicago
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: &port 5580
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              readiness: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 50m
+                memory: 256Mi
+    defaultPodOptions:
+      annotations:
+        # net1 on the IoT VLAN next to HA (.5) — see ../README.md.
+        k8s.v1.cni.cncf.io/networks: |
+          [{"name":"iot","namespace":"home-automation","ips":["10.1.30.6/24"]}]
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+    service:
+      app:
+        controller: matter-server
+        ports:
+          websocket:
+            primary: true
+            port: *port
+    persistence:
+      data:
+        existingClaim: matter-server
+        globalMounts:
+          - path: /data
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/home-automation/matter-server/app/kustomization.yaml
+++ b/kubernetes/apps/home-automation/matter-server/app/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/apps/home-automation/matter-server/ks.yaml
+++ b/kubernetes/apps/home-automation/matter-server/ks.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app matter-server
+  namespace: &namespace home-automation
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/volsync
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+    # NetworkAttachmentDefinition "iot" is owned by the home-assistant app.
+    - name: home-assistant
+      namespace: home-automation
+  interval: 1h
+  path: ./kubernetes/apps/home-automation/matter-server/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 1Gi
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false


### PR DESCRIPTION
## What

Deploys [matterjs-server](https://github.com/matter-js/matterjs-server) 1.2.7 in `home-automation` — the Open Home Foundation Matter controller for HA (successor to python-matter-server, which upstream declared EOL at 8.1.2). HA runs as Core in a container (no Supervisor), so this replaces the "official Matter Server add-on" that every guide assumes. Companion piece to the SMLIGHT SM Hub Nano now running OTBR on the IoT VLAN.

## Key decisions (details in the app README)

- **matterjs-server, not python-matter-server** — upstream rewrote the server on matter.js with a compatible WebSocket API and EOL'd the python line (8.1.2 final; its last two releases never even shipped container images). Beta / not yet CSA re-certified, but the only maintained option. Image bakes in `USER 1000:1000` and is configured via env vars (`PRIMARY_INTERFACE=net1`; `STORAGE_PATH=/data` is the default). Digest-pinned.
- **Multus `iot` attachment, `net1 = 10.1.30.6/24`** — the controller must share L2 with the border router for mDNS (`_meshcop`/Matter service proxying) and the OTBR's IPv6 RA route into the Thread mesh. Reuses the NAD owned by the home-assistant app (hence `dependsOn: home-assistant`); IP sits next to HA's `.5`, outside the DHCP pool.
- **Privileged sysctl initContainer** — sets `net.ipv6.conf.net1.accept_ra=2` + `accept_ra_rt_info_max_plen=64` in the pod netns. Linux drops RA Route Information Options by default, and without that route commissioning times out after the Thread handoff. Netns-scoped; simpler than an allowed-unsafe-sysctls kubelet change on all nodes.
- **volsync PVC (1Gi) on `/data`** — holds the Matter fabric credentials; losing it = re-commissioning every device.
- **ClusterIP only, no HTTPRoute** — the websocket API + dashboard (5580) are unauthenticated by design; port-forward for the dashboard.
- Probes hit the image's `/health` endpoint; non-root 1000 + readOnlyRootFilesystem.

## After merge (runtime, not in this PR)

1. HA → Add integration → Matter → **uncheck** "official add-on" → `ws://matter-server.home-automation.svc.cluster.local:5580/ws`
2. Verify the Thread route in the pod: `kubectl -n home-automation exec deploy/matter-server -- ip -6 route show dev net1` → expect `fd..::/64 via fe80::... proto ra`

## Validation

- `flux-local test` (kustomization level): 96 passed, includes the new ks
- `kustomize build` clean on app + namespace
- helm-level flux-local run is environment-blocked locally (sandbox 403s ghcr OCI pulls for *all* charts) — relying on CI here

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ho26Nnje7eHjXsHG2oCSnz