### PR TITLE
chore(media): strip gluetun-era VPN keys from qbit/slskd externalsecrets

### DIFF
--- a/kubernetes/apps/media/qbittorrent/app/externalsecret.yaml
+++ b/kubernetes/apps/media/qbittorrent/app/externalsecret.yaml
@@ -11,25 +11,8 @@ spec:
     name: qbittorrent-secret
     template:
       data:
-        VPN_SERVICE_PROVIDER: airvpn
-        WIREGUARD_PRIVATE_KEY: "{{ .WIREGUARD_PRIVATE_KEY }}"
-        WIREGUARD_PRESHARED_KEY: "{{ .WIREGUARD_PRESHARED_KEY }}"
-        WIREGUARD_ADDRESSES: "{{ .WIREGUARD_ADDRESSES }}"
-        SERVER_COUNTRIES: "{{ .SERVER_COUNTRIES }}"
         MOUSEHOLE_AUTH_PASSWORD: "{{ .MOUSEHOLE_AUTH_PASSWORD }}"
   data:
-    - secretKey: WIREGUARD_PRIVATE_KEY
-      remoteRef:
-        key: "fc5241cd-35c7-4b3f-9af2-b3fd007c8bcc"
-    - secretKey: WIREGUARD_PRESHARED_KEY
-      remoteRef:
-        key: "73a78fc9-9ff5-4186-adb3-b3fd007cb78e"
-    - secretKey: WIREGUARD_ADDRESSES
-      remoteRef:
-        key: "bf9d5113-16bb-4408-9950-b3fd007cda46"
-    - secretKey: SERVER_COUNTRIES
-      remoteRef:
-        key: "ba4cb37a-3fe4-428b-88c6-b3fd007d0adf"
     - secretKey: MOUSEHOLE_AUTH_PASSWORD
       remoteRef:
         key: "fb1279f4-6280-4e21-83c0-b462000ee6b5"

--- a/kubernetes/apps/media/slskd/app/externalsecret.yaml
+++ b/kubernetes/apps/media/slskd/app/externalsecret.yaml
@@ -11,28 +11,10 @@ spec:
     name: slskd-secret
     template:
       data:
-        VPN_SERVICE_PROVIDER: airvpn
-        WIREGUARD_PRIVATE_KEY: "{{ .WIREGUARD_PRIVATE_KEY }}"
-        WIREGUARD_PRESHARED_KEY: "{{ .WIREGUARD_PRESHARED_KEY }}"
-        WIREGUARD_ADDRESSES: "{{ .WIREGUARD_ADDRESSES }}"
-        SERVER_COUNTRIES: "{{ .SERVER_COUNTRIES }}"
         SLSKD_SLSK_USERNAME: "{{ .SLSKD_SLSK_USERNAME }}"
         SLSKD_SLSK_PASSWORD: "{{ .SLSKD_SLSK_PASSWORD }}"
-        FIREWALL_VPN_INPUT_PORTS: "{{ .SLSKD_FORWARDED_PORT }}"
         SLSKD_SLSK_LISTEN_PORT: "{{ .SLSKD_FORWARDED_PORT }}"
   data:
-    - secretKey: WIREGUARD_PRIVATE_KEY
-      remoteRef:
-        key: "8d965a4a-42e2-4216-b409-b40e007f9996"
-    - secretKey: WIREGUARD_PRESHARED_KEY
-      remoteRef:
-        key: "264a949e-b947-41a3-995c-b40e007fb7de"
-    - secretKey: WIREGUARD_ADDRESSES
-      remoteRef:
-        key: "17d891ff-36fd-488e-8cbd-b40e007fd6bc"
-    - secretKey: SERVER_COUNTRIES
-      remoteRef:
-        key: "290f6e84-f4ef-41a2-bdfd-b40e0080056a"
     - secretKey: SLSKD_SLSK_USERNAME
       remoteRef:
         key: "cce3dd16-4e35-473c-8e13-b40e008054d2"


### PR DESCRIPTION
## Summary
Post-migration cleanup for the gluetun→multus VLAN 70 cutover (#498/#499/#500/#501). Removes secret keys that only the (now-deleted) gluetun sidecars consumed:

- **qbittorrent-secret**: drops `VPN_SERVICE_PROVIDER`, `WIREGUARD_PRIVATE_KEY`, `WIREGUARD_PRESHARED_KEY`, `WIREGUARD_ADDRESSES`, `SERVER_COUNTRIES` — keeps only `MOUSEHOLE_AUTH_PASSWORD` (sole key referenced by the helmrelease, via secretKeyRef).
- **slskd-secret**: drops the same VPN keys plus `FIREWALL_VPN_INPUT_PORTS` — keeps `SLSKD_SLSK_USERNAME`, `SLSKD_SLSK_PASSWORD`, and `SLSKD_SLSK_LISTEN_PORT` (still the configured listener port on 192.168.70.33 and the DNAT target if an AirVPN inbound forward is added later). slskd consumes via `envFrom`, so removed keys simply vanish from the env.

## Verification (2026-07-20, pre-PR)
- 4d22h post-cutover soak: both pods 0 restarts, egress via AirVPN exit 134.19.179.243, qbit port 35338 externally reachable 5/5 (check-host.net), slskd Soulseek connected.
- `git grep` confirms no remaining consumer of any dropped key.

## Follow-up (not in this PR)
- Delete the backing Bitwarden SM entries for the dropped keys (IDs in the removed lines of this diff).
- Old AirVPN gluetun device sessions/ports can be retired account-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BpuEFQNWtXGM1sMmkgo8Bu