### PR TITLE
fix(home-assistant): mount emptyDir over /config/.venv to stop stale dep shadowing

### DIFF
--- a/kubernetes/apps/home-automation/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/home-assistant/app/helmrelease.yaml
@@ -136,3 +136,9 @@ spec:
         type: emptyDir
         globalMounts:
           - path: /tmp
+      # Rebuild the runtime venv per pod: persisted integration deps shadow the
+      # image's site-packages after core upgrades (home-operations/containers#1260)
+      venv:
+        type: emptyDir
+        globalMounts:
+          - path: /config/.venv


### PR DESCRIPTION
## Problem
After tonight's HA 2026.6.4 → 2026.7.2 upgrade (#468), the UI/app could not connect locally or remotely. HTTP served fine, but **every websocket connection crashed**:

```
TypeError: WebSocketResponse.__init__() got an unexpected keyword argument 'decode_text'
```

## Root cause
The home-operations image runs HA inside a venv at `/config/.venv` (on the config PVC) and reuses it across upgrades (`uv venv --allow-existing`). On July 3, integration requirements (ha_hatch → hatch_rest_api/awsiotsdk, frigate → hass_web_proxy_lib) pulled **aiohttp 3.13.5** into that venv. The 2026.7 image ships aiohttp 3.14.1, but the stale venv copy shadows it — and the entrypoint's uv bootstrap fails (`requirements are unsatisfiable`), so nothing ever refreshes it. Known upstream: home-operations/containers#1260 / #794 (identical signature on 2026.3/2026.4).

## Fix
Mount an emptyDir over `/config/.venv` — the community fix from #1260. The venv is rebuilt fresh against each image at pod start; integration requirements reinstall in seconds and can never go stale again. Merging this rolls the pod and immediately clears the current outage (the stale venv on the PVC is simply shadowed; can be deleted later at leisure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BpuEFQNWtXGM1sMmkgo8Bu