### PR TITLE
feat(talos): retarget install diskSelectors for Micron 7300 PRO swaps

### DIFF
--- a/talos/nodes/dvergar-00.yaml.j2
+++ b/talos/nodes/dvergar-00.yaml.j2
@@ -3,7 +3,7 @@ machine:
   type: controlplane
   install:
     diskSelector:
-      serial: IB25ZD0256P00073
+      model: Micron_7300*
   nodeLabels:
     clusterrole: highspeed
 ---

--- a/talos/nodes/dvergar-01.yaml.j2
+++ b/talos/nodes/dvergar-01.yaml.j2
@@ -3,7 +3,7 @@ machine:
   type: controlplane
   install:
     diskSelector:
-      serial: IB25ZD0256P00323
+      model: Micron_7300*
   nodeLabels:
     node.kubernetes.io/exclude-from-external-load-balancers: ""
 ---

--- a/talos/nodes/dvergar-02.yaml.j2
+++ b/talos/nodes/dvergar-02.yaml.j2
@@ -3,7 +3,7 @@ machine:
   type: controlplane
   install:
     diskSelector:
-      serial: IB25ZD0256P00322
+      model: Micron_7300*
   nodeLabels:
     node.kubernetes.io/exclude-from-external-load-balancers: ""
 ---

--- a/talos/nodes/dvergar-03.yaml.j2
+++ b/talos/nodes/dvergar-03.yaml.j2
@@ -3,7 +3,7 @@ machine:
   type: worker
   install:
     diskSelector:
-      serial: IB25ZD0256P00351
+      model: Micron_7300*
 ---
 apiVersion: v1alpha1
 kind: HostnameConfig

--- a/talos/nodes/dvergar-05.yaml.j2
+++ b/talos/nodes/dvergar-05.yaml.j2
@@ -3,7 +3,7 @@ machine:
   type: worker
   install:
     diskSelector:
-      serial: IB25ZD0256*
+      model: Micron_7300*
   nodeLabels:
     clusterrole: highspeed
 ---

--- a/talos/nodes/elli.yaml.j2
+++ b/talos/nodes/elli.yaml.j2
@@ -3,7 +3,7 @@ machine:
   type: worker
   install:
     diskSelector:
-      model: "Samsung SSD 850"
+      serial: IB25ZD0256*  # hand-me-down Inland TN320 (replaced failing 850 EVO, issue #424)
     # elli carries an RTX 3080 — it needs a different factory image than the rest
     # of the cluster (base schematic + the two NVIDIA extensions). Build the
     # schematic at https://factory.talos.dev with the FOUR extensions documented


### PR DESCRIPTION
## What

Updates `machine.install.diskSelector` for the system-disk replacement wave:

| Node | Before | After |
|------|--------|-------|
| dvergar-00 | `serial: IB25ZD0256P00073` (failing TN320) | `model: Micron_7300*` |
| dvergar-01 | `serial: IB25ZD0256P00323` | `model: Micron_7300*` |
| dvergar-02 | `serial: IB25ZD0256P00322` | `model: Micron_7300*` |
| dvergar-03 | `serial: IB25ZD0256P00351` | `model: Micron_7300*` |
| dvergar-05 | `serial: IB25ZD0256*` | `model: Micron_7300*` |
| elli | `model: "Samsung SSD 850"` (silently corrupting, #424) | `serial: IB25ZD0256*` (any hand-me-down TN320) |

## Why

- Model string verified live on dvergar-03 in maintenance mode: `Micron_7300_MTFDHBA480TDF` (480GB, PLP). One M.2 slot per OptiPlex, so a model glob is unambiguous and avoids reading each drive's serial at install time.
- elli takes any healthy pulled TN320 (serial glob covers all of them) — **do not** give it P00073, that one goes back for warranty.
- `install` is only consumed at install/upgrade time, so merging ahead of the remaining physical swaps is safe for running nodes.

## Rollout

One node at a time: `ceph osd set noout` → drain → `talosctl reset --graceful` → swap M.2 → boot Talos v1.13.2 USB → `task talos:join-node IP=<ip>` → verify Ready/HEALTH_OK → `unset noout`. dvergar-03 is already reset and waiting in maintenance mode as the first node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgHJawVsrGizm5M1KpTrtn