### PR TITLE
fix(talos): point elli install diskSelector at Intel DC S3510

### DIFF
--- a/talos/nodes/elli.yaml.j2
+++ b/talos/nodes/elli.yaml.j2
@@ -3,7 +3,7 @@ machine:
   type: worker
   install:
     diskSelector:
-      serial: IB25ZD0256*  # hand-me-down Inland TN320 (replaced failing 850 EVO, issue #424)
+      model: INTEL*  # Intel DC S3510 480GB (PLP, ex-HA box; replaced failing 850 EVO, issue #424)
     # elli carries an RTX 3080 — it needs a different factory image than the rest
     # of the cluster (base schematic + the two NVIDIA extensions). Build the
     # schematic at https://factory.talos.dev with the FOUR extensions documented


### PR DESCRIPTION
One-line follow-up to #521: elli gets the **Intel DC S3510 480GB** (PLP, enterprise MLC, pulled from the former HA box) instead of a TN320 hand-me-down — strictly better for the silent-corruption history in #424, and a direct 2.5" SATA drop-in.

Model verified live in maintenance mode on elli: `INTEL SSDSC2BB480G6` (WWID naa.55cd2e404c7001cf). `model: INTEL*` is unambiguous — it's the only Intel device in the box.

elli is currently down awaiting this merge + `task talos:join-node IP=192.168.100.30`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgHJawVsrGizm5M1KpTrtn