### PR TITLE
fix(barman-cloud): restart plugin on TLS cert renewal via reloader

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/barman-cloud/helmrelease.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/barman-cloud/helmrelease.yaml
@@ -26,3 +26,6 @@ spec:
       enabled: true
     cert-manager:
       enabled: false
+    commonAnnotations:
+      # plugin only loads its TLS certs at startup; restart on cert-manager renewal
+      reloader.stakater.com/auto: "true"


### PR DESCRIPTION
## Problem

On 2026-07-23 at 07:28 UTC, cert-manager renewed the `barman-cloud-server`/`barman-cloud-client` certificates (90-day self-signed certs). The plugin-barman-cloud pod only loads its serving cert at startup, so the 28-day-old pod kept serving the old cert while the CNPG operator trusted the renewed `ca.crt`. The mTLS handshake failed with:

```
x509: invalid signature: parent certificate cannot sign this kind of certificate
```

All 5 plugin-backed CNPG clusters (authelia-pg, lldap-pg, mealie-pg, reactive-resume-pg, vikunja-pg) went NotReady with "error while interacting with plugins", cascading to 5 FluxResourceNotReady alerts on their dependent app kustomizations. The hermod clusters were unaffected (no plugin usage).

Resolved manually with `kubectl rollout restart deploy -n database barman-cloud-plugin-barman-cloud`.

## Fix

Add `reloader.stakater.com/auto: "true"` to the plugin deployment via the chart's `commonAnnotations` (verified it renders onto the Deployment metadata). Both TLS secrets are mounted in the pod spec, so reloader restarts the deployment whenever cert-manager renews them — the next renewal (~2026-10-06) self-heals instead of breaking backups.

`commonAnnotations` also lands on the chart's other resources (service, certificates, RBAC); reloader ignores non-workload kinds, so this is harmless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EKHTcpduzRekW1e9U8iXy5