### PR TITLE
fix(talos): retarget dvergar-00 mgmt0 MAC to 7060 replacement hardware

### DIFF
--- a/talos/nodes/dvergar-00.yaml.j2
+++ b/talos/nodes/dvergar-00.yaml.j2
@@ -49,7 +49,7 @@ apiVersion: v1alpha1
 kind: LinkAliasConfig
 name: mgmt0
 selector:
-  match: mac(link.permanent_addr) == "c0:25:a5:98:c0:f6"
+  match: mac(link.permanent_addr) == "54:bf:64:8f:8b:9e"
 ---
 apiVersion: v1alpha1
 kind: LinkAliasConfig


### PR DESCRIPTION
## Summary
- dvergar-00's OptiPlex 3080 M.2 slot is dead (three drives failed to enumerate; Dell ePSA sees no disk). The ex-HA OptiPlex 7060 takes over the dvergar-00 identity.
- The Micron 7300 (`22383B82C367`) and osd.2's PM893 moved into the 7060 and both enumerate cleanly in maintenance mode.
- Onboard NIC MAC changes with the board: mgmt0 selector → `54:bf:64:8f:8b:9e` (7060 eno1, e1000e).
- ceph0 needs no change — the I226-V module moved with the drives and still matches `igc` + `02:26:26:02:0d:` prefix.

## Join procedure (after merge)
1. `git pull` in the ops checkout (also picks up the Micron diskSelector retarget this template relies on)
2. Reboot the 7060's Talos USB so it picks up the .20 static DHCP assignment
3. `bws run -- task talos:join-node IP=192.168.100.20` — pull USB at post-install reboot
4. Expect: etcd back to 3 voters, osd.2 auto-reactivates and backfills, mon count returns to full

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RDYQBxVVtXWpLxzWeiv7qa